### PR TITLE
Add static NONE value

### DIFF
--- a/Stellar-contract.x
+++ b/Stellar-contract.x
@@ -65,7 +65,8 @@ enum SCStatic
     SCS_VOID = 0,
     SCS_TRUE = 1,
     SCS_FALSE = 2,
-    SCS_LEDGER_KEY_CONTRACT_CODE_WASM = 3
+    SCS_LEDGER_KEY_CONTRACT_CODE_WASM = 3,
+    SCS_NONE = 4
 };
 
 enum SCStatusType

--- a/Stellar-contract.x
+++ b/Stellar-contract.x
@@ -62,10 +62,13 @@ enum SCValType
 
 enum SCStatic
 {
+    // Void indicates that no value is present and a value will not exist.
     SCS_VOID = 0,
     SCS_TRUE = 1,
     SCS_FALSE = 2,
     SCS_LEDGER_KEY_CONTRACT_CODE_WASM = 3,
+    // None indicates is useful with optional values, where no value is present
+    // but a value could exist at this location.
     SCS_NONE = 4
 };
 


### PR DESCRIPTION
### What
Add static NONE value.

### Why
For use in the host interface wherever a field could have a value or could not have a value. This is distinct from the static VOID value which should indicate that a field, such as a return value, will never have a value.

Close https://github.com/stellar/rs-stellar-contract-env/issues/105

cc @graydon @jonjove @jayz22 