### PR TITLE
Rename BINARY to BYTES

### DIFF
--- a/Stellar-contract-spec.x
+++ b/Stellar-contract-spec.x
@@ -21,7 +21,7 @@ enum SCSpecType
     SC_SPEC_TYPE_SYMBOL = 6,
     SC_SPEC_TYPE_BITSET = 7,
     SC_SPEC_TYPE_STATUS = 8,
-    SC_SPEC_TYPE_BINARY = 9,
+    SC_SPEC_TYPE_BYTES = 9,
     SC_SPEC_TYPE_BIG_INT = 10,
 
     // Types with parameters.
@@ -83,7 +83,7 @@ case SC_SPEC_TYPE_BOOL:
 case SC_SPEC_TYPE_SYMBOL:
 case SC_SPEC_TYPE_BITSET:
 case SC_SPEC_TYPE_STATUS:
-case SC_SPEC_TYPE_BINARY:
+case SC_SPEC_TYPE_BYTES:
 case SC_SPEC_TYPE_BIG_INT:
     void;
 case SC_SPEC_TYPE_OPTION:

--- a/Stellar-contract.x
+++ b/Stellar-contract.x
@@ -210,7 +210,7 @@ enum SCObjectType
     SCO_MAP = 1,
     SCO_U64 = 2,
     SCO_I64 = 3,
-    SCO_BINARY = 4,
+    SCO_BYTES = 4,
     SCO_BIG_INT = 5,
     SCO_HASH = 6,
     SCO_PUBLIC_KEY = 7
@@ -266,7 +266,7 @@ case SCO_U64:
     uint64 u64;
 case SCO_I64:
     int64 i64;
-case SCO_BINARY:
+case SCO_BYTES:
     opaque bin<SCVAL_LIMIT>;
 case SCO_BIG_INT:
     SCBigInt bigInt;


### PR DESCRIPTION
### What
Rename all references to BINARY to BYTES.

### Why
Binary is a somewhat confusing term. When I see it in the docs it doesn't scream at me that this is the type for storing byte slices or byte arrays. Doing a quick survey of Ethereum, they use the term Bytes in both Solidity and Vyper. Thinking back to whenever I have explained Binary to others or in my head, I immediately reach for the term "bytes"

Related https://github.com/stellar/rs-soroban-sdk/pull/394
Close https://github.com/stellar/rs-soroban-sdk/issues/385