### PR TITLE
Add names to function inputs in contract spec

### DIFF
--- a/Stellar-contract-spec.x
+++ b/Stellar-contract-spec.x
@@ -126,11 +126,17 @@ struct SCSpecUDTUnionV0
     SCSpecUDTUnionCaseV0 cases<50>;
 };
 
+struct SCSpecFunctionInputV0
+{
+    string name<30>;
+    SCSpecTypeDef type;
+};
+
 struct SCSpecFunctionV0
 {
     SCSymbol name;
-    SCSpecTypeDef inputTypes<10>;
-    SCSpecTypeDef outputTypes<1>;
+    SCSpecFunctionInputV0 inputs<10>;
+    SCSpecTypeDef outputs<1>;
 };
 
 enum SCSpecEntryKind


### PR DESCRIPTION
### What
Add names to function inputs in contract spec.

### Why
When defining an interface it is helpful to give names to the arguments of the functions so a user of the interface knows what to put in the arguments. This is especially helpful when multiple arguments have the same type, since a name is the only thing that distinguishes them.

Close https://github.com/stellar/rs-soroban-sdk/issues/434