### PR TITLE
Pick up changes incorrectly committed to rs-stellar-xdr

### DIFF
--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -359,6 +359,33 @@ struct TransactionMetaV2
                                         // applied if any
 };
 
+enum ContractEventType
+{
+    SYSTEM = 0,
+    CONTRACT = 1
+};
+
+struct ContractEvent
+{
+    // We can use this to add more fields, or because it
+    // is first, to change ContractEvent into a union.
+    ExtensionPoint ext;
+
+    Hash* contractID;
+    ContractEventType type;
+
+    union switch (int v)
+    {
+    case 0:
+        struct
+        {
+            SCVec topics;
+            SCVal data;
+        } v0;
+    }
+    body;
+};
+
 // this is the meta produced when applying transactions
 // it does not include pre-apply updates such as fees
 union TransactionMeta switch (int v)


### PR DESCRIPTION
Some recent XDR changes were incorrectly committed directly to rs-stellar-xdr. They should have been committed to this repo, with the rs-stellar-xdr repo updated _from_ here, so that core also sees them in the C++ side when it updates from here too.

This change just picks up those changes. I will next regenerate rs-stellar-xdr from them.

cc @jayz22 and @sisuresh 