### PR TITLE
Add name of lib to struct and union spec entries

### DIFF
--- a/Stellar-contract-spec.x
+++ b/Stellar-contract-spec.x
@@ -121,6 +121,7 @@ struct SCSpecUDTStructFieldV0
 
 struct SCSpecUDTStructV0
 {
+    string lib<80>;
     string name<60>;
     SCSpecUDTStructFieldV0 fields<40>;
 };
@@ -133,6 +134,7 @@ struct SCSpecUDTUnionCaseV0
 
 struct SCSpecUDTUnionV0
 {
+    string lib<80>;
     string name<60>;
     SCSpecUDTUnionCaseV0 cases<50>;
 };


### PR DESCRIPTION
### What
Add name of lib to struct and union spec entries.

### Why
So that struct and union spec entries can indicate which libs they're available in.