### PR TITLE
Update configuration-related XDR

### DIFF
--- a/Stellar-ledger-entries.x
+++ b/Stellar-ledger-entries.x
@@ -499,33 +499,15 @@ struct ContractDataEntry {
     SCVal val;
 };
 
-enum ConfigSettingType
-{
-    CONFIG_SETTING_TYPE_UINT32 = 0
-};
-
-union ConfigSetting switch (ConfigSettingType type)
-{
-case CONFIG_SETTING_TYPE_UINT32:
-    uint32 uint32Val;
-};
-
 enum ConfigSettingID
 {
-    CONFIG_SETTING_CONTRACT_MAX_SIZE = 0
+    CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES = 0
 };
 
-struct ConfigSettingEntry
+union ConfigSettingEntry switch (ConfigSettingID configSettingID)
 {
-    union switch (int v)
-    {
-    case 0:
-        void;
-    }
-    ext;
-
-    ConfigSettingID configSettingID;
-    ConfigSetting setting;
+case CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES:
+    uint32 contractMaxSizeBytes;
 };
 
 struct LedgerEntryExtensionV1

--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -143,11 +143,11 @@ case LEDGER_UPGRADE_BASE_RESERVE:
 case LEDGER_UPGRADE_FLAGS:
     uint32 newFlags; // update flags
 case LEDGER_UPGRADE_CONFIG:
-    struct
-    {
-        ConfigSettingID id; // id to update
-        ConfigSetting setting; // new value
-    } configSetting;
+    Hash configUpgradeSetHash;
+};
+
+struct ConfigUpgradeSet {
+    ConfigSettingEntry updatedEntry<>;
 };
 
 /* Entries used to define the bucket list */

--- a/Stellar-overlay.x
+++ b/Stellar-overlay.x
@@ -83,7 +83,7 @@ struct PeerAddress
     uint32 numFailures;
 };
 
-// Next ID: 18
+// Next ID: 20
 enum MessageType
 {
     ERROR_MSG = 0,
@@ -113,7 +113,11 @@ enum MessageType
 
     SEND_MORE = 16,
     FLOOD_ADVERT = 18,
-    FLOOD_DEMAND = 19
+    FLOOD_DEMAND = 19,
+    
+    // Configuration upgrades
+    GET_CONFIG_UPGRADE_SET = 20,
+    CONFIG_UPGRADE_SET = 21
 };
 
 struct DontHave
@@ -242,6 +246,11 @@ case SURVEY_REQUEST:
 
 case SURVEY_RESPONSE:
     SignedSurveyResponseMessage signedSurveyResponseMessage;
+
+case GET_CONFIG_UPGRADE_SET:
+    uint256 configUgradeSetHash;
+case CONFIG_UPGRADE_SET:
+    ConfigUpgradeSet configUpgradeSet;
 
 // SCP
 case GET_SCP_QUORUMSET:


### PR DESCRIPTION
The changes here are summarized in proposed update to CAP-47 (https://github.com/stellar/stellar-protocol/pull/1291).

- Use unique keys to identify settings
- Only distribute a hash for config upgrades in `StellarValue`
- Add SCP messages for exchanging config upgrade sets