### PR TITLE
Add SST_CONTRACT_ERROR to SCStatusType

### DIFF
--- a/Stellar-contract.x
+++ b/Stellar-contract.x
@@ -77,7 +77,8 @@ enum SCStatusType
     SST_HOST_FUNCTION_ERROR = 4,
     SST_HOST_STORAGE_ERROR = 5,
     SST_HOST_CONTEXT_ERROR = 6,
-    SST_VM_ERROR = 7
+    SST_VM_ERROR = 7,
+    SST_CONTRACT_ERROR = 8
     // TODO: add more
 };
 
@@ -179,6 +180,8 @@ case SST_HOST_CONTEXT_ERROR:
     SCHostContextErrorCode contextCode;
 case SST_VM_ERROR:
     SCVmErrorCode vmCode;
+case SST_CONTRACT_ERROR:
+    uint32 contractCode;
 };
 
 union SCVal switch (SCValType type)


### PR DESCRIPTION
### What
Add SST_CONTRACT_ERROR to SCStatusType

### Why
It should be possible for contracts to create their own status error codes that are clearly separated from all errors that the host could create. For this we need a new ScStatusType, something like ContractError should do. The codes within that type of error would be undefined by the XDR and any u32 value could be used. It would be up to contracts to define what they are.

Close #28 