### PR TITLE
Remove SST_CONTRACT_ERROR

### DIFF
--- a/Stellar-contract.x
+++ b/Stellar-contract.x
@@ -78,7 +78,6 @@ enum SCStatusType
     SST_HOST_STORAGE_ERROR = 5,
     SST_HOST_CONTEXT_ERROR = 6,
     SST_VM_ERROR = 7,
-    SST_CONTRACT_ERROR = 8
     // TODO: add more
 };
 
@@ -180,8 +179,6 @@ case SST_HOST_CONTEXT_ERROR:
     SCHostContextErrorCode contextCode;
 case SST_VM_ERROR:
     SCVmErrorCode vmCode;
-case SST_CONTRACT_ERROR:
-    uint32 contractCode;
 };
 
 union SCVal switch (SCValType type)


### PR DESCRIPTION
### What
Remove SST_CONTRACT_ERROR.

### Why
It is no longer needed because user defined errors will be communicated via Result<> and Status will continue to be used as it was for host errors, or panics anywhere in the call path.

Related to https://github.com/stellar/rs-soroban-sdk/pull/601