### PR TITLE
Use LF line endings for XDR.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.x text -merge eol=lf


### PR DESCRIPTION
This is to make hash checks consistent across Rust/C++ repos.