### PR TITLE
Change the size limit of bytes and wasm code to 15mb

### DIFF
--- a/Stellar-contract.x
+++ b/Stellar-contract.x
@@ -227,6 +227,7 @@ struct SCMapEntry
 };
 
 const SCVAL_LIMIT = 256000;
+const SCVAL_BYTES_LIMIT = 15000000;
 
 typedef SCVal SCVec<SCVAL_LIMIT>;
 typedef SCMapEntry SCMap<SCVAL_LIMIT>;
@@ -256,7 +257,7 @@ enum SCContractCodeType
 union SCContractCode switch (SCContractCodeType type)
 {
 case SCCONTRACT_CODE_WASM:
-    opaque wasm<SCVAL_LIMIT>;
+    opaque wasm<SCVAL_BYTES_LIMIT>;
 case SCCONTRACT_CODE_TOKEN:
     void;
 };
@@ -272,7 +273,7 @@ case SCO_U64:
 case SCO_I64:
     int64 i64;
 case SCO_BYTES:
-    opaque bin<SCVAL_LIMIT>;
+    opaque bin<SCVAL_BYTES_LIMIT>;
 case SCO_BIG_INT:
     SCBigInt bigInt;
 case SCO_CONTRACT_CODE:


### PR DESCRIPTION
### What
Change the size limit of bytes and wasm code to ~15mb.

### Why
I think we need a larger size for bytes and wasm code, because while we expect on-chain contracts to be under 256KB, if a developer wants to deploy some sort of debug WASM build that contains debug events and other things, they will blow past that limit almost immediately even on small contracts.

We already discussed about how stellar-core is likely to specify some smaller limit that is configurable in any case, so this is just a sensible upper maximum for the XDR format.

Related to https://github.com/stellar/rs-soroban-env/issues/447