### PR TITLE
Add error enum as a distinct UDT type from enum

### DIFF
--- a/Stellar-contract-spec.x
+++ b/Stellar-contract-spec.x
@@ -152,6 +152,19 @@ struct SCSpecUDTEnumV0
     SCSpecUDTEnumCaseV0 cases<50>;
 };
 
+struct SCSpecUDTErrorEnumCaseV0
+{
+    string name<60>;
+    uint32 value;
+};
+
+struct SCSpecUDTErrorEnumV0
+{
+    string lib<80>;
+    string name<60>;
+    SCSpecUDTErrorEnumCaseV0 cases<50>;
+};
+
 struct SCSpecFunctionInputV0
 {
     string name<30>;
@@ -170,7 +183,8 @@ enum SCSpecEntryKind
     SC_SPEC_ENTRY_FUNCTION_V0 = 0,
     SC_SPEC_ENTRY_UDT_STRUCT_V0 = 1,
     SC_SPEC_ENTRY_UDT_UNION_V0 = 2,
-    SC_SPEC_ENTRY_UDT_ENUM_V0 = 3
+    SC_SPEC_ENTRY_UDT_ENUM_V0 = 3,
+    SC_SPEC_ENTRY_UDT_ERROR_ENUM_V0 = 4
 };
 
 union SCSpecEntry switch (SCSpecEntryKind kind)
@@ -183,6 +197,8 @@ case SC_SPEC_ENTRY_UDT_UNION_V0:
     SCSpecUDTUnionV0 udtUnionV0;
 case SC_SPEC_ENTRY_UDT_ENUM_V0:
     SCSpecUDTEnumV0 udtEnumV0;
+case SC_SPEC_ENTRY_UDT_ERROR_ENUM_V0:
+    SCSpecUDTErrorEnumV0 udtErrorEnumV0;
 };
 
 }


### PR DESCRIPTION
### What
Add error enum as a distinct UDT type from enum

### Why
It will be useful to distinguish error types from regular types, so that they are not confused or usable interchangeably.