### PR TITLE
Add account id as object type

### DIFF
--- a/Stellar-contract.x
+++ b/Stellar-contract.x
@@ -215,7 +215,8 @@ enum SCObjectType
     SCO_I64 = 3,
     SCO_BYTES = 4,
     SCO_BIG_INT = 5,
-    SCO_CONTRACT_CODE = 6
+    SCO_CONTRACT_CODE = 6,
+    SCO_ACCOUNT_ID = 7
 
     // TODO: add more
 };
@@ -277,5 +278,7 @@ case SCO_BIG_INT:
     SCBigInt bigInt;
 case SCO_CONTRACT_CODE:
     SCContractCode contractCode;
+case SCO_ACCOUNT_ID:
+    AccountID accountID;
 };
 }


### PR DESCRIPTION
### What
Add account id as object type

### Why
We'll be exposing account IDs to contracts since they're a type of invoker.