### PR TITLE
move AccountID to avoid circular reference

### DIFF
--- a/Stellar-ledger-entries.x
+++ b/Stellar-ledger-entries.x
@@ -8,7 +8,6 @@
 namespace stellar
 {
 
-typedef PublicKey AccountID;
 typedef opaque Thresholds[4];
 typedef string string32<32>;
 typedef string string64<64>;

--- a/Stellar-types.x
+++ b/Stellar-types.x
@@ -79,6 +79,7 @@ typedef opaque Signature<64>;
 typedef opaque SignatureHint[4];
 
 typedef PublicKey NodeID;
+typedef PublicKey AccountID;
 
 struct Curve25519Secret
 {


### PR DESCRIPTION
`AccountID`, which is in `Stellar-ledger-entries.x`, is now being used in `Stellar-contract.x`.  `Stellar-contract.x` is included in `Stellar-ledger-entries.x`, so this caused a circular reference.