### PR TITLE
Add XDR types for contract meta

### DIFF
--- a/Stellar-contract-meta.x
+++ b/Stellar-contract-meta.x
@@ -9,15 +9,21 @@
 namespace stellar
 {
 
+struct SCMetaV0
+{
+    string key<10>;
+    string val<256>;
+};
+
 enum SCMetaKind
 {
-    SC_META_KIND_SDK = 0
+    SC_META_V0 = 0
 };
 
 union SCMetaEntry switch (SCMetaKind kind)
 {
-case SC_META_KIND_SDK:
-    string sdk<256>;
+case SC_META_V0:
+    SCMetaV0 v0;
 };
 
 }

--- a/Stellar-contract-meta.x
+++ b/Stellar-contract-meta.x
@@ -1,0 +1,23 @@
+// Copyright 2022 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+// The contract spec XDR is highly experimental, incomplete, and still being
+// iterated on. Breaking changes expected.
+
+% #include "xdr/Stellar-types.h"
+namespace stellar
+{
+
+enum SCMetaKind
+{
+    SC_META_KIND_SDK = 0
+};
+
+union SCMetaEntry switch (SCMetaKind kind)
+{
+case SC_META_KIND_SDK:
+    string sdk<256>;
+};
+
+}


### PR DESCRIPTION
### What
Add XDR types for contract meta to contain meta information about how the contract.

### Why
So that we have an XDR structure to store generic meta information in contracts. The intent will be to store information such as the `soroban-sdk` version, and the `soroban-auth` version.