### PR TITLE
Make events a list of lists so we can associate events with their operation

### DIFF
--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -419,8 +419,8 @@ struct TransactionMetaV3
     OperationMeta operations<>;         // meta for each operation
     LedgerEntryChanges txChangesAfter;  // tx level changes after operations are
                                         // applied if any
-    ContractEvent events<>;            // custom events populated by the
-                                        // contracts themselves
+    ContractEvent events<><>;           // custom events populated by the
+                                        // contracts themselves. One list per operation.
     TransactionResult txResult;
 
     Hash hashes[3];                     // stores sha256(txChangesBefore, operations, txChangesAfter),

--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -412,6 +412,11 @@ struct ContractEvent
     body;
 };
 
+struct OperationEvents
+{
+    ContractEvent events<>;
+};
+
 struct TransactionMetaV3
 {
     LedgerEntryChanges txChangesBefore; // tx level changes before operations
@@ -419,7 +424,7 @@ struct TransactionMetaV3
     OperationMeta operations<>;         // meta for each operation
     LedgerEntryChanges txChangesAfter;  // tx level changes after operations are
                                         // applied if any
-    ContractEvent events<><>;           // custom events populated by the
+    OperationEvents events<>;           // custom events populated by the
                                         // contracts themselves. One list per operation.
     TransactionResult txResult;
 


### PR DESCRIPTION
With the old schema, it is impossible to tell which operations emitted which events. This is not an issue now, as there is only one operation in soroban txns, but if we support multiple in future, it would be an issue. To prevent that we can change the events field to be a list of lists (one list per operation).

Two questions:
- Anywhere else we need to update this? (aside from propagating it through core/soroban-cli/go/js/etc...)
- Do we need the OperationEvents struct? Is there a simpler way to do an inline nested list?