### PR TITLE
Replace BigInt object with {iu}128

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,11 +4,11 @@ name: CI
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
+  # Triggers the workflow on push or pull request events for main, curr or next.
   push:
-    branches: [ "main" ]
+    branches: [ "main", "curr", "next" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "curr", "next" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/Stellar-contract.x
+++ b/Stellar-contract.x
@@ -213,10 +213,11 @@ enum SCObjectType
     SCO_MAP = 1,
     SCO_U64 = 2,
     SCO_I64 = 3,
-    SCO_BYTES = 4,
-    SCO_BIG_INT = 5,
-    SCO_CONTRACT_CODE = 6,
-    SCO_ACCOUNT_ID = 7
+    SCO_U128 = 4,
+    SCO_I128 = 5,
+    SCO_BYTES = 6,
+    SCO_CONTRACT_CODE = 7,
+    SCO_ACCOUNT_ID = 8
 
     // TODO: add more
 };
@@ -232,22 +233,6 @@ const SCVAL_LIMIT = 256000;
 typedef SCVal SCVec<SCVAL_LIMIT>;
 typedef SCMapEntry SCMap<SCVAL_LIMIT>;
 
-enum SCNumSign
-{
-    NEGATIVE = -1,
-    ZERO = 0,
-    POSITIVE = 1
-};
-
-union SCBigInt switch (SCNumSign sign)
-{
-case ZERO:
-    void;
-case POSITIVE:
-case NEGATIVE:
-    opaque magnitude<256000>;
-};
-
 enum SCContractCodeType
 {
     SCCONTRACT_CODE_WASM_REF = 0,
@@ -262,6 +247,14 @@ case SCCONTRACT_CODE_TOKEN:
     void;
 };
 
+struct Int128Parts {
+    // Both signed and unsigned 128-bit ints
+    // are transported in a pair of uint64s
+    // to reduce the risk of sign-extension.
+    uint64 lo;
+    uint64 hi;
+};
+
 union SCObject switch (SCObjectType type)
 {
 case SCO_VEC:
@@ -272,10 +265,12 @@ case SCO_U64:
     uint64 u64;
 case SCO_I64:
     int64 i64;
+case SCO_U128:
+    Int128Parts u128;
+case SCO_I128:
+    Int128Parts i128;
 case SCO_BYTES:
     opaque bin<SCVAL_LIMIT>;
-case SCO_BIG_INT:
-    SCBigInt bigInt;
 case SCO_CONTRACT_CODE:
     SCContractCode contractCode;
 case SCO_ACCOUNT_ID:


### PR DESCRIPTION
This shifts the XDR from having a BigInt type to having u128 and i128 types. It's the conclusion of a long conversation about the fate of integer types. We might add larger fixed-size integer types in future versions (eg. u256 or u512) but we're going to remove the arbitrary-size Bigint given a lack of motivation for keeping it and a variety of difficulties arising from its use.