### PR TITLE
Make events a list of lists so we can associate events with their operation

### DIFF
--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -419,8 +419,8 @@ struct TransactionMetaV3
     OperationMeta operations<>;         // meta for each operation
     LedgerEntryChanges txChangesAfter;  // tx level changes after operations are
                                         // applied if any
-    ContractEvent events<>;            // custom events populated by the
-                                        // contracts themselves
+    ContractEvent events<><>;           // custom events populated by the
+                                        // contracts themselves. One list per operation.
     TransactionResult txResult;
 
     Hash hashes[3];                     // stores sha256(txChangesBefore, operations, txChangesAfter),

--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -412,6 +412,11 @@ struct ContractEvent
     body;
 };
 
+struct OperationEvents
+{
+    ContractEvent events<>;
+};
+
 struct TransactionMetaV3
 {
     LedgerEntryChanges txChangesBefore; // tx level changes before operations
@@ -419,7 +424,7 @@ struct TransactionMetaV3
     OperationMeta operations<>;         // meta for each operation
     LedgerEntryChanges txChangesAfter;  // tx level changes after operations are
                                         // applied if any
-    ContractEvent events<><>;           // custom events populated by the
+    OperationEvents events<>;           // custom events populated by the
                                         // contracts themselves. One list per operation.
     TransactionResult txResult;
 


### PR DESCRIPTION
Re-opening https://github.com/stellar/stellar-xdr/pull/52 against the new `next` branch.