### PR TITLE
Make unit/void case explicit and support more tuples in union spec

### DIFF
--- a/Stellar-contract-spec.x
+++ b/Stellar-contract-spec.x
@@ -157,9 +157,9 @@ enum SCSpecUDTUnionCaseV0Kind
 union SCSpecUDTUnionCaseV0 switch (SCSpecUDTUnionCaseV0Kind kind)
 {
 case SC_SPEC_UDT_UNION_CASE_VOID_V0:
-    SCSpecUDTUnionCaseVoidV0 void;
+    SCSpecUDTUnionCaseVoidV0 voidCase;
 case SC_SPEC_UDT_UNION_CASE_TUPLE_V0:
-    SCSpecUDTUnionCaseTupleV0 tuple;
+    SCSpecUDTUnionCaseTupleV0 tupleCase;
 };
 
 struct SCSpecUDTUnionV0

--- a/Stellar-contract-spec.x
+++ b/Stellar-contract-spec.x
@@ -135,11 +135,31 @@ struct SCSpecUDTStructV0
     SCSpecUDTStructFieldV0 fields<40>;
 };
 
-struct SCSpecUDTUnionCaseV0
+struct SCSpecUDTUnionCaseVoidV0
 {
     string doc<SC_SPEC_DOC_LIMIT>;
     string name<60>;
-    SCSpecTypeDef *type;
+};
+
+struct SCSpecUDTUnionCaseTupleV0
+{
+    string doc<SC_SPEC_DOC_LIMIT>;
+    string name<60>;
+    SCSpecTypeDef type<12>;
+};
+
+enum SCSpecUDTUnionCaseV0Kind
+{
+    SC_SPEC_UDT_UNION_CASE_VOID_V0 = 0,
+    SC_SPEC_UDT_UNION_CASE_TUPLE_V0 = 1,
+};
+
+union SCSpecUDTUnionCaseV0 switch (SCSpecUDTUnionCaseV0Kind kind)
+{
+case SC_SPEC_UDT_UNION_CASE_VOID_V0:
+    SCSpecUDTUnionCaseVoidV0 void;
+case SC_SPEC_UDT_UNION_CASE_TUPLE_V0:
+    SCSpecUDTUnionCaseTupleV0 tuple;
 };
 
 struct SCSpecUDTUnionV0


### PR DESCRIPTION
### What
Make unit/void case explicit and support more tuple values in unions in the contract spec.

### Why
@brson is adding support for multiple value tuples in the contract spec. We need to change the union case spec to support multiple types so that a union case can contain more than one value.

While making that change I realized that we should probably distinguish between unit (void) and tuple variant types because an empty tuple and unit variant aren't exactly the same.

And by having a discriminant in there for them we can also add struct-like variants in the future if we choose to in a way that isn't breaking.

For https://github.com/stellar/rs-soroban-sdk/pull/850