### PR TITLE
Remove all TransactionResultSetV2 related changes and puts the hash of the events and return values in InvokeHostFunctionResult

### DIFF
--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -60,17 +60,6 @@ enum LedgerHeaderFlags
     DISABLE_CONTRACT_INVOKE = 0x40
 };
 
-struct LedgerHeaderExtensionV2
-{
-    Hash txMetaHashSetHash; // sha256(TxHashOfMetaHashesSet)
-    union switch (int v)
-    {
-    case 0:
-        void;
-    }
-    ext;
-};
-
 struct LedgerHeaderExtensionV1
 {
     uint32 flags; // LedgerHeaderFlags
@@ -79,8 +68,6 @@ struct LedgerHeaderExtensionV1
     {
     case 0:
         void;
-    case 2:
-        LedgerHeaderExtensionV2 v2;
     }
     ext;
 };
@@ -293,14 +280,6 @@ struct TransactionHistoryResultEntry
     ext;
 };
 
-struct TxHashOfMetaHashesSet
-{
-    // Each one is the hash of hashes in TransactionMetaV3.
-    // The index corresponds to the transaction that emitted
-    // the meta that was hashed.
-    Hash hashOfMetaHashes<>; 
-};
-
 struct LedgerHeaderHistoryEntry
 {
     Hash hash;
@@ -438,9 +417,6 @@ struct TransactionMetaV3
                                         // applied if any
     OperationEvents events<>;           // custom events populated by the
                                         // contracts themselves. One list per operation.
-
-    Hash hashes[2];                     // stores sha256(txChangesBefore, operations, txChangesAfter),
-                                        // sha256(events)
 
     // Diagnostics events that are not hashed. One list per operation.
     // This will contain all contract and diagnostic events. Even ones

--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -407,11 +407,19 @@ struct TransactionMetaV3
                                         // applied if any
     ContractEvent events<>;           // custom events populated by the
                                         // contracts themselves.
+    SCVal returnValues<MAX_OPS_PER_TX>;    // return values of each invocation.
 
     // Diagnostics events that are not hashed.
     // This will contain all contract and diagnostic events. Even ones
     // that were emitted in a failed contract call.
     DiagnosticEvent diagnosticEvents<>;
+};
+
+// This is in Stellar-ledger.x to due to a circular dependency 
+struct InvokeHostFunctionSuccessPreImage
+{
+    SCVal returnValues<MAX_OPS_PER_TX>;
+    ContractEvent events<>;
 };
 
 // this is the meta produced when applying transactions

--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -398,16 +398,6 @@ struct DiagnosticEvent
     ContractEvent event;
 };
 
-struct OperationDiagnosticEvents
-{
-    DiagnosticEvent events<>;
-};
-
-struct OperationEvents
-{
-    ContractEvent events<>;
-};
-
 struct TransactionMetaV3
 {
     LedgerEntryChanges txChangesBefore; // tx level changes before operations
@@ -415,13 +405,13 @@ struct TransactionMetaV3
     OperationMeta operations<>;         // meta for each operation
     LedgerEntryChanges txChangesAfter;  // tx level changes after operations are
                                         // applied if any
-    OperationEvents events<>;           // custom events populated by the
-                                        // contracts themselves. One list per operation.
+    ContractEvent events<>;           // custom events populated by the
+                                        // contracts themselves.
 
-    // Diagnostics events that are not hashed. One list per operation.
+    // Diagnostics events that are not hashed.
     // This will contain all contract and diagnostic events. Even ones
     // that were emitted in a failed contract call.
-    OperationDiagnosticEvents diagnosticEvents<>;
+    DiagnosticEvent diagnosticEvents<>;
 };
 
 // this is the meta produced when applying transactions

--- a/Stellar-transaction.x
+++ b/Stellar-transaction.x
@@ -1779,7 +1779,7 @@ enum InvokeHostFunctionResultCode
 union InvokeHostFunctionResult switch (InvokeHostFunctionResultCode code)
 {
 case INVOKE_HOST_FUNCTION_SUCCESS:
-    SCVal success<MAX_OPS_PER_TX>;
+    Hash success; // sha256(InvokeHostFunctionSuccessPreImage)
 case INVOKE_HOST_FUNCTION_MALFORMED:
 case INVOKE_HOST_FUNCTION_TRAPPED:
 case INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED:


### PR DESCRIPTION
Related to https://github.com/stellar/stellar-core/issues/3555#issuecomment-1504168200 and used in https://github.com/stellar/stellar-core/pull/3714.