### PR TITLE
Change cost param type to int64

### DIFF
--- a/Stellar-contract-config-setting.x
+++ b/Stellar-contract-config-setting.x
@@ -129,13 +129,14 @@ enum ContractCostType {
 };
 
 struct ContractCostParamEntry {
-    int32 constTerm;
-    int32 linearTerm;
+    int64 constTerm;
+    int64 linearTerm;
     // use `ext` to add more terms (e.g. higher order polynomials) in the future
     ExtensionPoint ext;
 };
 
-const CONTRACT_COST_COUNT_LIMIT = 1024; // limits the ContractCostParams size to 12kB
+// limits the ContractCostParams size to 20kB
+const CONTRACT_COST_COUNT_LIMIT = 1024;
 
 typedef ContractCostParamEntry ContractCostParams<CONTRACT_COST_COUNT_LIMIT>;
 


### PR DESCRIPTION
Change cost param type from int32 to int64.
It is conceivable a single param (e.g. a constant cost type) could one day reach int32::MAX. Now we have multi-invoke and the budget per tx could become over 2bn cpu instructions. 
The entry size increase is insignificant. 