### PR TITLE
Err reform

### DIFF
--- a/Stellar-contract-spec.x
+++ b/Stellar-contract-spec.x
@@ -19,7 +19,7 @@ enum SCSpecType
     // Types with no parameters.
     SC_SPEC_TYPE_BOOL = 1,
     SC_SPEC_TYPE_VOID = 2,
-    SC_SPEC_TYPE_STATUS = 3,
+    SC_SPEC_TYPE_ERROR = 3,
     SC_SPEC_TYPE_U32 = 4,
     SC_SPEC_TYPE_I32 = 5,
     SC_SPEC_TYPE_U64 = 6,
@@ -95,7 +95,7 @@ union SCSpecTypeDef switch (SCSpecType type)
 case SC_SPEC_TYPE_VAL:
 case SC_SPEC_TYPE_BOOL:
 case SC_SPEC_TYPE_VOID:
-case SC_SPEC_TYPE_STATUS:
+case SC_SPEC_TYPE_ERROR:
 case SC_SPEC_TYPE_U32:
 case SC_SPEC_TYPE_I32:
 case SC_SPEC_TYPE_U64:

--- a/Stellar-contract.x
+++ b/Stellar-contract.x
@@ -49,9 +49,6 @@ enum SCValType
     SCV_U256 = 11,
     SCV_I256 = 12,
 
-    // TODO: possibly allocate subtypes of i64, i128 and/or u256 for
-    // fixed-precision with a specific number of decimals.
-
     // Bytes come in 3 flavors, 2 of which have meaningfully different
     // formatting and validity-checking / domain-restriction.
     SCV_BYTES = 13,

--- a/Stellar-contract.x
+++ b/Stellar-contract.x
@@ -22,7 +22,7 @@ enum SCValType
 {
     SCV_BOOL = 0,
     SCV_VOID = 1,
-    SCV_STATUS = 2,
+    SCV_ERROR = 2,
 
     // 32 bits is the smallest type in WASM or XDR; no need for u8/u16.
     SCV_U32 = 3,
@@ -71,131 +71,38 @@ enum SCValType
     SCV_LEDGER_KEY_NONCE = 21
 };
 
-enum SCStatusType
+enum SCErrorType
 {
-    SST_OK = 0,
-    SST_UNKNOWN_ERROR = 1,
-    SST_HOST_VALUE_ERROR = 2,
-    SST_HOST_OBJECT_ERROR = 3,
-    SST_HOST_FUNCTION_ERROR = 4,
-    SST_HOST_STORAGE_ERROR = 5,
-    SST_HOST_CONTEXT_ERROR = 6,
-    SST_VM_ERROR = 7,
-    SST_CONTRACT_ERROR = 8,
-    SST_HOST_AUTH_ERROR = 9
-    // TODO: add more
+    SCE_CONTRACT = 0,
+    SCE_WASM_VM = 1,
+    SCE_CONTEXT = 2,
+    SCE_STORAGE = 3,
+    SCE_OBJECT = 4,
+    SCE_CRYPTO = 5,
+    SCE_EVENTS = 6,
+    SCE_BUDGET = 7,
+    SCE_VALUE = 8,
+    SCE_AUTH = 9
 };
 
-enum SCHostValErrorCode
+enum SCErrorCode
 {
-    HOST_VALUE_UNKNOWN_ERROR = 0,
-    HOST_VALUE_RESERVED_TAG_VALUE = 1,
-    HOST_VALUE_UNEXPECTED_VAL_TYPE = 2,
-    HOST_VALUE_U63_OUT_OF_RANGE = 3,
-    HOST_VALUE_U32_OUT_OF_RANGE = 4,
-    HOST_VALUE_STATIC_UNKNOWN = 5,
-    HOST_VALUE_MISSING_OBJECT = 6,
-    HOST_VALUE_SYMBOL_TOO_LONG = 7,
-    HOST_VALUE_SYMBOL_BAD_CHAR = 8,
-    HOST_VALUE_SYMBOL_CONTAINS_NON_UTF8 = 9,
-    HOST_VALUE_BITSET_TOO_MANY_BITS = 10,
-    HOST_VALUE_STATUS_UNKNOWN = 11
+    SCEC_ARITH_DOMAIN = 0,      // some arithmetic wasn't defined (overflow, divide-by-zero)
+    SCEC_INDEX_BOUNDS = 1,      // something was indexed beyond its bounds
+    SCEC_INVALID_INPUT = 2,     // user provided some otherwise-bad data
+    SCEC_MISSING_VALUE = 3,     // some value was required but not provided
+    SCEC_EXISTING_VALUE = 4,    // some value was provided where not allowed
+    SCEC_EXCEEDED_LIMIT = 5,    // some arbitrary limit -- gas or otherwise -- was hit
+    SCEC_INVALID_ACTION = 6,    // data was valid but action requested was not
+    SCEC_INTERNAL_ERROR = 7,    // the internal state of the host was otherwise-bad
+    SCEC_UNEXPECTED_TYPE = 8,   // some type wasn't as expected
+    SCEC_UNEXPECTED_SIZE = 9    // something's size wasn't as expected
 };
 
-enum SCHostObjErrorCode
+struct SCError
 {
-    HOST_OBJECT_UNKNOWN_ERROR = 0,
-    HOST_OBJECT_UNKNOWN_REFERENCE = 1,
-    HOST_OBJECT_UNEXPECTED_TYPE = 2,
-    HOST_OBJECT_OBJECT_COUNT_EXCEEDS_U32_MAX = 3,
-    HOST_OBJECT_OBJECT_NOT_EXIST = 4,
-    HOST_OBJECT_VEC_INDEX_OUT_OF_BOUND = 5,
-    HOST_OBJECT_CONTRACT_HASH_WRONG_LENGTH = 6
-};
-
-enum SCHostFnErrorCode
-{
-    HOST_FN_UNKNOWN_ERROR = 0,
-    HOST_FN_UNEXPECTED_HOST_FUNCTION_ACTION = 1,
-    HOST_FN_INPUT_ARGS_WRONG_LENGTH = 2,
-    HOST_FN_INPUT_ARGS_WRONG_TYPE = 3,
-    HOST_FN_INPUT_ARGS_INVALID = 4
-};
-
-enum SCHostStorageErrorCode
-{
-    HOST_STORAGE_UNKNOWN_ERROR = 0,
-    HOST_STORAGE_EXPECT_CONTRACT_DATA = 1,
-    HOST_STORAGE_READWRITE_ACCESS_TO_READONLY_ENTRY = 2,
-    HOST_STORAGE_ACCESS_TO_UNKNOWN_ENTRY = 3,
-    HOST_STORAGE_MISSING_KEY_IN_GET = 4,
-    HOST_STORAGE_GET_ON_DELETED_KEY = 5
-};
-
-enum SCHostAuthErrorCode
-{
-    HOST_AUTH_UNKNOWN_ERROR = 0,
-    HOST_AUTH_NONCE_ERROR = 1,
-    HOST_AUTH_DUPLICATE_AUTHORIZATION = 2,
-    HOST_AUTH_NOT_AUTHORIZED = 3
-};
-
-enum SCHostContextErrorCode
-{
-    HOST_CONTEXT_UNKNOWN_ERROR = 0,
-    HOST_CONTEXT_NO_CONTRACT_RUNNING = 1
-};
-
-enum SCVmErrorCode {
-    VM_UNKNOWN = 0,
-    VM_VALIDATION = 1,
-    VM_INSTANTIATION = 2,
-    VM_FUNCTION = 3,
-    VM_TABLE = 4,
-    VM_MEMORY = 5,
-    VM_GLOBAL = 6,
-    VM_VALUE = 7,
-    VM_TRAP_UNREACHABLE = 8,
-    VM_TRAP_MEMORY_ACCESS_OUT_OF_BOUNDS = 9,
-    VM_TRAP_TABLE_ACCESS_OUT_OF_BOUNDS = 10,
-    VM_TRAP_ELEM_UNINITIALIZED = 11,
-    VM_TRAP_DIVISION_BY_ZERO = 12,
-    VM_TRAP_INTEGER_OVERFLOW = 13,
-    VM_TRAP_INVALID_CONVERSION_TO_INT = 14,
-    VM_TRAP_STACK_OVERFLOW = 15,
-    VM_TRAP_UNEXPECTED_SIGNATURE = 16,
-    VM_TRAP_MEM_LIMIT_EXCEEDED = 17,
-    VM_TRAP_CPU_LIMIT_EXCEEDED = 18
-};
-
-enum SCUnknownErrorCode
-{
-    UNKNOWN_ERROR_GENERAL = 0,
-    UNKNOWN_ERROR_XDR = 1
-};
-
-union SCStatus switch (SCStatusType type)
-{
-case SST_OK:
-    void;
-case SST_UNKNOWN_ERROR:
-    SCUnknownErrorCode unknownCode;
-case SST_HOST_VALUE_ERROR:
-    SCHostValErrorCode valCode;
-case SST_HOST_OBJECT_ERROR:
-    SCHostObjErrorCode objCode;
-case SST_HOST_FUNCTION_ERROR:
-    SCHostFnErrorCode fnCode;
-case SST_HOST_STORAGE_ERROR:
-    SCHostStorageErrorCode storageCode;
-case SST_HOST_CONTEXT_ERROR:
-    SCHostContextErrorCode contextCode;
-case SST_VM_ERROR:
-    SCVmErrorCode vmCode;
-case SST_CONTRACT_ERROR:
-    uint32 contractCode;
-case SST_HOST_AUTH_ERROR:
-    SCHostAuthErrorCode authCode;
+    SCErrorType type;
+    SCErrorCode code;
 };
 
 struct UInt128Parts {
@@ -282,8 +189,8 @@ case SCV_BOOL:
     bool b;
 case SCV_VOID:
     void;
-case SCV_STATUS:
-    SCStatus error;
+case SCV_ERROR:
+    SCError error;
 
 case SCV_U32:
     uint32 u32;


### PR DESCRIPTION
This is a stab at https://github.com/stellar/rs-soroban-env/issues/225 -- redoing the error codes to reflect what we've seen in practice and the evolution of the codebase since last summer when they were first assigned.

I took the following approach:

1. I collected all the existing codes and uses of `err_general`, erased all codes that are currently unused, and picked out natural groups of the remainder that mean roughly the same thing.
2. I merged such groups fairly aggressively when they were "almost the same", assuming we'll augment the error-generation sites with detail in the form of structured diagnostic events (as discussed in https://github.com/stellar/rs-soroban-env/issues/673)
3. I wanted to make the 2-level encoding of errors _orthogonal_ -- a separate `type` and `code` in a simple struct rather than a union with different codes per case -- so I pushed any aspect of an error code that identified an area-of-concern into the `type` argument and only kept separate codes when they had different residual meaning.

I also included the renaming of `ScStatus` -> `ScError` as discussed in https://github.com/stellar/rs-soroban-env/issues/689 -- I'll do the other renamings in subsequent passes.