### PR TITLE
Remove trailing ,

### DIFF
--- a/Stellar-transaction.x
+++ b/Stellar-transaction.x
@@ -544,7 +544,7 @@ struct AddressAuthorization
 enum AuthorizationType
 {
     AUTHORIZATION_SOURCE_ACCOUNT = 0,
-    AUTHORIZATION_ADDRESS = 1,
+    AUTHORIZATION_ADDRESS = 1
 };
 
 union Authorization switch (AuthorizationType type)


### PR DESCRIPTION
### What
Remove trailing ,

### Why
Trailing commas on end of enums are not allowed.