### PR TITLE
Make `returnValue` optional in meta.

### DIFF
--- a/Stellar-contract-config-setting.x
+++ b/Stellar-contract-config-setting.x
@@ -129,10 +129,11 @@ enum ContractCostType {
 };
 
 struct ContractCostParamEntry {
-    int64 constTerm;
-    int64 linearTerm;
     // use `ext` to add more terms (e.g. higher order polynomials) in the future
     ExtensionPoint ext;
+    
+    int64 constTerm;
+    int64 linearTerm;
 };
 
 struct StateExpirationSettings {

--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -398,21 +398,31 @@ struct DiagnosticEvent
     ContractEvent event;
 };
 
-struct TransactionMetaV3
+struct SorobanTransactionMeta 
 {
-    LedgerEntryChanges txChangesBefore; // tx level changes before operations
-                                        // are applied if any
-    OperationMeta operations<>;         // meta for each operation
-    LedgerEntryChanges txChangesAfter;  // tx level changes after operations are
-                                        // applied if any
+    ExtensionPoint ext;
+
     ContractEvent events<>;             // custom events populated by the
                                         // contracts themselves.
-    SCVal* returnValue;                 // return value of the host fn invocation (if any)
+    SCVal returnValue;                  // return value of the host fn invocation
 
     // Diagnostics events that are not hashed.
     // This will contain all contract and diagnostic events. Even ones
     // that were emitted in a failed contract call.
     DiagnosticEvent diagnosticEvents<>;
+}
+
+struct TransactionMetaV3
+{
+    ExtensionPoint ext;
+
+    LedgerEntryChanges txChangesBefore;  // tx level changes before operations
+                                         // are applied if any
+    OperationMeta operations<>;          // meta for each operation
+    LedgerEntryChanges txChangesAfter;   // tx level changes after operations are
+                                         // applied if any
+    SorobanTransactionMeta* sorobanMeta; // Soroban-specific meta (only for 
+                                         // Soroban transactions).
 };
 
 // This is in Stellar-ledger.x to due to a circular dependency 

--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -407,7 +407,7 @@ struct TransactionMetaV3
                                         // applied if any
     ContractEvent events<>;             // custom events populated by the
                                         // contracts themselves.
-    SCVal returnValue;                  // return value of the invocation.
+    SCVal* returnValue;                 // return value of the host fn invocation (if any)
 
     // Diagnostics events that are not hashed.
     // This will contain all contract and diagnostic events. Even ones

--- a/Stellar-transaction.x
+++ b/Stellar-transaction.x
@@ -789,10 +789,10 @@ struct SorobanResources
 // The transaction extension for Soroban.
 struct SorobanTransactionData
 {
+    ExtensionPoint ext;
     SorobanResources resources;
     // Portion of transaction `fee` allocated to refundable fees.
     int64 refundableFee;
-    ExtensionPoint ext;
 };
 
 // TransactionV0 is a transaction with the AccountID discriminant stripped off,


### PR DESCRIPTION
This is meaningless for non-Soroban txs.