### PR TITLE
Switch Soroban nonces from autoincrement to random values with signature expiration.

### DIFF
--- a/Stellar-contract.x
+++ b/Stellar-contract.x
@@ -187,7 +187,7 @@ typedef string SCString<>;
 typedef string SCSymbol<SCSYMBOL_LIMIT>;
 
 struct SCNonceKey {
-    SCAddress nonce_address;
+    int64 nonce;
 };
 
 union SCVal switch (SCValType type)

--- a/Stellar-ledger-entries.x
+++ b/Stellar-ledger-entries.x
@@ -507,7 +507,7 @@ enum ContractDataFlags {
 };
 
 struct ContractDataEntry {
-    Hash contractID;
+    SCAddress contract;
     SCVal key;
     ContractDataType type;
 
@@ -635,7 +635,7 @@ case LIQUIDITY_POOL:
 case CONTRACT_DATA:
     struct
     {
-        Hash contractID;
+        SCAddress contract;
         SCVal key;
         ContractDataType type;
         ContractLedgerEntryType leType;

--- a/Stellar-transaction.x
+++ b/Stellar-transaction.x
@@ -541,7 +541,8 @@ struct SorobanAuthorizedInvocation
 struct SorobanAddressCredentials
 {
     SCAddress address;
-    uint64 nonce;
+    int64 nonce;
+    uint32 signatureExpirationLedger;    
     SCVec signatureArgs;
 };
 
@@ -670,7 +671,8 @@ case ENVELOPE_TYPE_SOROBAN_AUTHORIZATION:
     struct
     {
         Hash networkID;
-        uint64 nonce;
+        int64 nonce;
+        uint32 signatureExpirationLedger;
         SorobanAuthorizedInvocation invocation;
     } sorobanAuthorization;
 };


### PR DESCRIPTION
Combined with temp entries this provides a cheaper and more concurrency-friendly way to prevent signature replay than auto-increments.