### PR TITLE
Adds expiration iterator

### DIFF
--- a/Stellar-contract-config-setting.x
+++ b/Stellar-contract-config-setting.x
@@ -47,7 +47,7 @@ struct ConfigSettingContractLedgerCostV0
     int64 feeReadLedgerEntry;  // Fee per ledger entry read
     int64 feeWriteLedgerEntry; // Fee per ledger entry write
 
-    int64 feeRead1KB;  // Fee for reading 1KB    
+    int64 feeRead1KB;  // Fee for reading 1KB
     int64 feeWrite1KB; // Fee for writing 1KB
 
     // Bucket list fees grow slowly up to that size
@@ -138,7 +138,7 @@ enum ContractCostType {
 struct ContractCostParamEntry {
     // use `ext` to add more terms (e.g. higher order polynomials) in the future
     ExtensionPoint ext;
-    
+
     int64 constTerm;
     int64 linearTerm;
 };
@@ -146,37 +146,21 @@ struct ContractCostParamEntry {
 struct StateExpirationSettings {
     uint32 maxEntryExpiration;
     uint32 minTempEntryExpiration;
-    uint32 minRestorableEntryExpiration;
+    uint32 minPersistentEntryExpiration;
     uint32 autoBumpLedgers;
 
     // rent_fee = wfee_rate_average / rent_rate_denominator_for_type
-    int64 restorableRentRateDenominator;
+    int64 persistentRentRateDenominator;
     int64 tempRentRateDenominator;
 
     // max number of entries that emit expiration meta in a single ledger
     uint32 maxEntriesToExpire;
 
-    // maximum bytes to scan the BucketList for expired entries in a single ledger, in megabytes
-    uint32 maxBytesToScan;
+    // Number of snapshots to use when calculating average BucketList size
+    uint32 bucketListSizeWindowSampleSize;
 
-    union switch (int v)
-    {
-    case 0:
-        void;
-    } ext;
-};
-
-// Points to BucketEntry in BucketList where expiration scan last stopped
-struct ExpirationIterator {
-    uint32 bucketListLevel;
-    bool isCurrBucket;
-    uint64 bucketFileOffset;
-
-    union switch (int v)
-    {
-    case 0:
-        void;
-    } ext;
+    // Maximum number of bytes that we scan for eviction per ledger
+    uint64 evictionScanSize;
 };
 
 // limits the ContractCostParams size to 20kB
@@ -199,7 +183,7 @@ enum ConfigSettingID
     CONFIG_SETTING_CONTRACT_DATA_ENTRY_SIZE_BYTES = 9,
     CONFIG_SETTING_STATE_EXPIRATION = 10,
     CONFIG_SETTING_CONTRACT_EXECUTION_LANES = 11,
-    CONFIG_SETTING_EXPIRATION_ITERATOR = 12
+    CONFIG_SETTING_BUCKETLIST_SIZE_WINDOW = 12
 };
 
 union ConfigSettingEntry switch (ConfigSettingID configSettingID)
@@ -228,7 +212,7 @@ case CONFIG_SETTING_STATE_EXPIRATION:
     StateExpirationSettings stateExpirationSettings;
 case CONFIG_SETTING_CONTRACT_EXECUTION_LANES:
     ConfigSettingContractExecutionLanesV0 contractExecutionLanes;
-case CONFIG_SETTING_EXPIRATION_ITERATOR:
-    ExpirationIterator expirationIterator;
+case CONFIG_SETTING_BUCKETLIST_SIZE_WINDOW:
+    uint64 bucketListSizeWindow<>;
 };
 }

--- a/Stellar-contract-config-setting.x
+++ b/Stellar-contract-config-setting.x
@@ -153,6 +153,25 @@ struct StateExpirationSettings {
     int64 restorableRentRateDenominator;
     int64 tempRentRateDenominator;
 
+    // max number of entries that emit expiration meta in a single ledger
+    uint32 maxEntriesToExpire;
+
+    // maximum bytes to scan the BucketList for expired entries in a single ledger, in megabytes
+    uint32 maxBytesToScan;
+
+    union switch (int v)
+    {
+    case 0:
+        void;
+    } ext;
+};
+
+// Points to BucketEntry in BucketList where expiration scan last stopped
+struct ExpirationIterator {
+    uint32 bucketListLevel;
+    bool isCurrBucket;
+    uint64 bucketFileOffset;
+
     union switch (int v)
     {
     case 0:
@@ -179,7 +198,8 @@ enum ConfigSettingID
     CONFIG_SETTING_CONTRACT_DATA_KEY_SIZE_BYTES = 8,
     CONFIG_SETTING_CONTRACT_DATA_ENTRY_SIZE_BYTES = 9,
     CONFIG_SETTING_STATE_EXPIRATION = 10,
-    CONFIG_SETTING_CONTRACT_EXECUTION_LANES = 11
+    CONFIG_SETTING_CONTRACT_EXECUTION_LANES = 11,
+    CONFIG_SETTING_EXPIRATION_ITERATOR = 12
 };
 
 union ConfigSettingEntry switch (ConfigSettingID configSettingID)
@@ -208,5 +228,7 @@ case CONFIG_SETTING_STATE_EXPIRATION:
     StateExpirationSettings stateExpirationSettings;
 case CONFIG_SETTING_CONTRACT_EXECUTION_LANES:
     ConfigSettingContractExecutionLanesV0 contractExecutionLanes;
+case CONFIG_SETTING_EXPIRATION_ITERATOR:
+    ExpirationIterator expirationIterator;
 };
 }


### PR DESCRIPTION
This adds an `ExpirationIterator` for managing how core emits expiration meta. We want to limit the amount of entries we expire in a given ledger to not strain downstream systems. This is necessary because there can be an arbitrary number of entries that can have a given expiration ledger, so we have to send meta in batches. The idea of the `ExpirationIterator` is that we gradually scan the entire BucketList. On each ledger close, we scan `maxBytesToScan` megabytes of the BucketList and expire up to `maxEntriesToExpire` entries. These two configuration options ensure that we keep up to date with expired entries while not slowing down close time due to too much disk IO or overburdening downstream systems.

To keep track of where we are in the BucketList while scanning, we write the `ExpirationIterator` on every ledger close. It's not really a `ConfigSettingEntry` but that was the most convenient place to put it. We have to store it somewhere on the BucketList so new nodes joining the network know where to start expiration, and it also needs to be updated on each ledger close. I think `ConfigSettingEntry` is the best way to do that currently even though semantically the iterator is not a config setting.

In previous proposals, we discussed creating a new type of Bucket called the "expiration" Bucket that is produced on merges. We would iterate through specific key bounds on a given expiration bucket based on some modulo arithmetic on the current ledger number. This seemed complicated, and adding a new bucket type was controversial. This approach should be much more straightforward, although we may have to tune the `maxEntriesToExpire` and `maxBytesToScan` values over time to not lag behind too much w.r.t. expiring data.