### PR TITLE
Remove ContractDataType from ScVal and rename

### DIFF
--- a/Stellar-contract.x
+++ b/Stellar-contract.x
@@ -66,13 +66,12 @@ enum SCValType
     // The following are the internal SCVal variants that are not
     // exposed to the contracts. 
     SCV_CONTRACT_INSTANCE = 19,
-    SCV_STORAGE_TYPE = 20,
 
     // SCV_LEDGER_KEY_CONTRACT_INSTANCE and SCV_LEDGER_KEY_NONCE are unique
     // symbolic SCVals used as the key for ledger entries for a contract's
     // instance and an address' nonce, respectively.
-    SCV_LEDGER_KEY_CONTRACT_INSTANCE = 21,
-    SCV_LEDGER_KEY_NONCE = 22
+    SCV_LEDGER_KEY_CONTRACT_INSTANCE = 20,
+    SCV_LEDGER_KEY_NONCE = 21
 };
 
 enum SCErrorType
@@ -169,12 +168,6 @@ case SC_ADDRESS_TYPE_CONTRACT:
     Hash contractId;
 };
 
-// Here due to circular dependency
-enum ContractDataType {
-    TEMPORARY = 0,
-    PERSISTENT = 1
-};
-
 %struct SCVal;
 %struct SCMapEntry;
 
@@ -253,9 +246,6 @@ case SCV_LEDGER_KEY_CONTRACT_INSTANCE:
     void;
 case SCV_LEDGER_KEY_NONCE:
     SCNonceKey nonce_key;
-
-case SCV_STORAGE_TYPE:
-    ContractDataType storageType;
 
 case SCV_CONTRACT_INSTANCE:
     SCContractInstance instance;

--- a/Stellar-ledger-entries.x
+++ b/Stellar-ledger-entries.x
@@ -493,7 +493,7 @@ struct LiquidityPoolEntry
     body;
 };
 
-enum ContractLedgerEntryType {
+enum ContractEntryBodyType {
     DATA_ENTRY = 0,
     EXPIRATION_EXTENSION = 1
 };
@@ -506,12 +506,17 @@ enum ContractDataFlags {
     NO_AUTOBUMP = 0x1
 };
 
+enum ContractDataDurability {
+    TEMPORARY = 0,
+    PERSISTENT = 1
+};
+
 struct ContractDataEntry {
     SCAddress contract;
     SCVal key;
-    ContractDataType type;
+    ContractDataDurability durability;
 
-    union switch (ContractLedgerEntryType leType)
+    union switch (ContractEntryBodyType bodyType)
     {
     case DATA_ENTRY:
     struct
@@ -530,7 +535,7 @@ struct ContractCodeEntry {
     ExtensionPoint ext;
 
     Hash hash;
-    union switch (ContractLedgerEntryType leType)
+    union switch (ContractEntryBodyType bodyType)
     {
     case DATA_ENTRY:
         opaque code<>;
@@ -637,14 +642,14 @@ case CONTRACT_DATA:
     {
         SCAddress contract;
         SCVal key;
-        ContractDataType type;
-        ContractLedgerEntryType leType;
+        ContractDataDurability durability;
+        ContractEntryBodyType bodyType;
     } contractData;
 case CONTRACT_CODE:
     struct
     {
         Hash hash;
-        ContractLedgerEntryType leType;
+        ContractEntryBodyType bodyType;
     } contractCode;
 case CONFIG_SETTING:
     struct


### PR DESCRIPTION
- Remove `SCV_STORAGE_TYPE` and `ContractDataType` from `ScVal`
- Rename `ContractDataType` to `ContractDataDurability`
- Move it to `Stellar-ledger-entries.x`
- Rename `ContractLedgerEntryType` to `ContractEntryBodyType` 