### PR TITLE
Make `SCContractInstance` a pointer in `ScVal`.

### DIFF
--- a/Stellar-contract.x
+++ b/Stellar-contract.x
@@ -186,7 +186,7 @@ struct SCNonceKey {
 
 struct SCContractInstance {
     ContractExecutable executable;
-    SCMap* storage;
+    SCMap storage;
 };
 
 union SCVal switch (SCValType type)
@@ -248,7 +248,7 @@ case SCV_LEDGER_KEY_NONCE:
     SCNonceKey nonce_key;
 
 case SCV_CONTRACT_INSTANCE:
-    SCContractInstance instance;
+    SCContractInstance* instance;
 };
 
 struct SCMapEntry


### PR DESCRIPTION
This makes `SCVal` smaller at cost of making instance entries slightly larger, which should be a net win.

This also makes it easier to use the storage in `ScContractInstance` as it can't be in two 'empty' states (null or empty map).