### PR TITLE
Soroban tx set size upgrade support and XDR cleanup.

### DIFF
--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -127,7 +127,8 @@ enum LedgerUpgradeType
     LEDGER_UPGRADE_MAX_TX_SET_SIZE = 3,
     LEDGER_UPGRADE_BASE_RESERVE = 4,
     LEDGER_UPGRADE_FLAGS = 5,
-    LEDGER_UPGRADE_CONFIG = 6
+    LEDGER_UPGRADE_CONFIG = 6,
+    LEDGER_UPGRADE_MAX_SOROBAN_TX_SET_SIZE = 7
 };
 
 struct ConfigUpgradeSetKey {
@@ -148,7 +149,12 @@ case LEDGER_UPGRADE_BASE_RESERVE:
 case LEDGER_UPGRADE_FLAGS:
     uint32 newFlags; // update flags
 case LEDGER_UPGRADE_CONFIG:
+    // Update arbitray `ConfigSetting` entries identified by the key.
     ConfigUpgradeSetKey newConfig;
+case LEDGER_UPGRADE_MAX_SOROBAN_TX_SET_SIZE:
+    // Update ConfigSettingContractExecutionLanesV0.ledgerMaxTxCount without
+    // using `LEDGER_UPGRADE_CONFIG`.
+    uint32 newMaxSorobanTxSetSize;
 };
 
 struct ConfigUpgradeSet {
@@ -385,7 +391,7 @@ struct ContractEvent
     case 0:
         struct
         {
-            SCVec topics;
+            SCVal topics<>;
             SCVal data;
         } v0;
     }

--- a/Stellar-transaction.x
+++ b/Stellar-transaction.x
@@ -503,10 +503,16 @@ struct CreateContractArgs
     ContractExecutable executable;
 };
 
+struct InvokeContractArgs {
+    SCAddress contractAddress;
+    SCSymbol functionName;
+    SCVal args<>;
+};
+
 union HostFunction switch (HostFunctionType type)
 {
 case HOST_FUNCTION_TYPE_INVOKE_CONTRACT:
-    SCVec invokeContract;
+    InvokeContractArgs invokeContract;
 case HOST_FUNCTION_TYPE_CREATE_CONTRACT:
     CreateContractArgs createContract;
 case HOST_FUNCTION_TYPE_UPLOAD_CONTRACT_WASM:
@@ -519,17 +525,10 @@ enum SorobanAuthorizedFunctionType
     SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_HOST_FN = 1
 };
 
-struct SorobanAuthorizedContractFunction 
-{
-    SCAddress contractAddress;
-    SCSymbol functionName;
-    SCVec args;
-};
-
 union SorobanAuthorizedFunction switch (SorobanAuthorizedFunctionType type)
 {
 case SOROBAN_AUTHORIZED_FUNCTION_TYPE_CONTRACT_FN:
-    SorobanAuthorizedContractFunction contractFn;
+    InvokeContractArgs contractFn;
 case SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_HOST_FN:
     CreateContractArgs createContractHostFn;
 };
@@ -545,7 +544,7 @@ struct SorobanAddressCredentials
     SCAddress address;
     int64 nonce;
     uint32 signatureExpirationLedger;    
-    SCVec signatureArgs;
+    SCVal signature;
 };
 
 enum SorobanCredentialsType


### PR DESCRIPTION
- Use dedicated struct for `InvokeContract` host fn
- Replace `ScVec` with `SCVal` or `SCVal<>` depending on the context