### PR TITLE
Make SCError into a union to allow user errors to be u32

### DIFF
--- a/Stellar-contract.x
+++ b/Stellar-contract.x
@@ -102,9 +102,19 @@ enum SCErrorCode
     SCEC_UNEXPECTED_SIZE = 9    // something's size wasn't as expected
 };
 
-struct SCError
+union SCError switch (SCErrorType type)
 {
-    SCErrorType type;
+case SCE_CONTRACT:
+    uint32 contractCode;
+case SCE_WASM_VM:
+case SCE_CONTEXT:
+case SCE_STORAGE:
+case SCE_OBJECT:
+case SCE_CRYPTO:
+case SCE_EVENTS:
+case SCE_BUDGET:
+case SCE_VALUE:
+case SCE_AUTH:
     SCErrorCode code;
 };
 


### PR DESCRIPTION
Fixes https://github.com/stellar/rs-soroban-env/issues/953 by moving the case for contract code into a plain u32 not SCErrorCode. Accompanying rs-xdr and env-{common,host} changes seem relatively small.