### PR TITLE
Remove incorrect comment about Soroban u256 representation

### DIFF
--- a/Stellar-contract.x
+++ b/Stellar-contract.x
@@ -38,8 +38,7 @@ enum SCValType
 
     // 128 bits is naturally supported by Rust and we use it for Soroban
     // fixed-point arithmetic prices / balances / similar "quantities". These
-    // are represented in XDR as a pair of 2 u64s, unlike {u,i}256 which is
-    // represented as an array of 32 bytes.
+    // are represented in XDR as a pair of 2 u64s.
     SCV_U128 = 9,
     SCV_I128 = 10,
 


### PR DESCRIPTION
u256 is no longer represented as an array of bytes. It is represented as u64s similarly to the u128 case, so there's no comparison needed here.