### PR TITLE
Match with curr

### DIFF
--- a/Stellar-ledger-entries.x
+++ b/Stellar-ledger-entries.x
@@ -521,7 +521,6 @@ struct ExpirationEntry {
     uint32 expirationLedgerSeq;
 };
 
-
 struct LedgerEntryExtensionV1
 {
     SponsorshipDescriptor sponsoringID;

--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -145,7 +145,7 @@ case LEDGER_UPGRADE_BASE_RESERVE:
 case LEDGER_UPGRADE_FLAGS:
     uint32 newFlags; // update flags
 case LEDGER_UPGRADE_CONFIG:
-    // Update arbitray `ConfigSetting` entries identified by the key.
+    // Update arbitrary `ConfigSetting` entries identified by the key.
     ConfigUpgradeSetKey newConfig;
 case LEDGER_UPGRADE_MAX_SOROBAN_TX_SET_SIZE:
     // Update ConfigSettingContractExecutionLanesV0.ledgerMaxTxCount without


### PR DESCRIPTION
Some small changes to make the .x files between curr and next identical for hashing purposes. We'll still need to make a change in core to use curr vs next when doing the xdr hash check.