### PR TITLE
Remove unused LedgerCloseMeta struct

### DIFF
--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -486,26 +486,8 @@ struct LedgerCloseMetaV0
 
 struct LedgerCloseMetaV1
 {
-    LedgerHeaderHistoryEntry ledgerHeader;
-
-    GeneralizedTransactionSet txSet;
-
-    // NB: transactions are sorted in apply order here
-    // fees for all transactions are processed first
-    // followed by applying transactions
-    TransactionResultMeta txProcessing<>;
-
-    // upgrades are applied last
-    UpgradeEntryMeta upgradesProcessing<>;
-
-    // other misc information attached to the ledger close
-    SCPHistoryEntry scpInfo<>;
-};
-
-struct LedgerCloseMetaV2
-{
-    // We forgot to add an ExtensionPoint in v1 but at least
-    // we can add one now in v2.
+    // We forgot to add an ExtensionPoint in v0 but at least
+    // we can add one now in v1.
     ExtensionPoint ext;
 
     LedgerHeaderHistoryEntry ledgerHeader;
@@ -541,7 +523,5 @@ case 0:
     LedgerCloseMetaV0 v0;
 case 1:
     LedgerCloseMetaV1 v1;
-case 2:
-    LedgerCloseMetaV2 v2;
 };
 }


### PR DESCRIPTION
`LedgerCloseMetaFrameV1` is never used since it's been superseded by `LedgerCloseMetaFrameV2`. Using v1 in protocol 20 is invalid, yet the code currently allows this, which makes it harder to spot bugs related to wrong versioning. This removes `LedgerCloseMetaFrameV1` and renames what was previously `LedgerCloseMetaFrameV2` to V1.