### PR TITLE
Change the semantics of Soroban `refundableFee` to be `resourceFee` covering all the resources

### DIFF
--- a/Stellar-transaction.x
+++ b/Stellar-transaction.x
@@ -821,8 +821,16 @@ struct SorobanTransactionData
 {
     ExtensionPoint ext;
     SorobanResources resources;
-    // Portion of transaction `fee` allocated to refundable fees.
-    int64 refundableFee;
+    // Amount of the transaction `fee` allocated to the Soroban resource fees.
+    // The fraction of `resourceFee` corresponding to `resources` specified 
+    // above is *not* refundable (i.e. fees for instructions, ledger I/O), as
+    // well as fees for the transaction size.
+    // The remaining part of the fee is refundable and the charged value is
+    // based on the actual consumption of refundable resources (events, ledger
+    // rent bumps).
+    // The `inclusionFee` used for prioritization of the transaction is defined
+    // as `tx.fee - resourceFee`.
+    int64 resourceFee;
 };
 
 // TransactionV0 is a transaction with the AccountID discriminant stripped off,


### PR DESCRIPTION
Change the semantics of Soroban `refundableFee` to be `resourceFee` covering all the resources.

The motivation is to allow stable prioritization of transactions independent of the network configuration (the inclusion fee is always constant).
