### PR TITLE
Clean up, consolidate cost types

### DIFF
--- a/Stellar-contract-config-setting.x
+++ b/Stellar-contract-config-setting.x
@@ -92,66 +92,54 @@ struct ConfigSettingContractBandwidthV0
 enum ContractCostType {
     // Cost of running 1 wasm instruction
     WasmInsnExec = 0,
-    // Cost of growing wasm linear memory by 1 page
-    WasmMemAlloc = 1,
-    // Cost of allocating a chuck of host memory (in bytes)
-    HostMemAlloc = 2,
-    // Cost of copying a chuck of bytes into a pre-allocated host memory
-    HostMemCpy = 3,
-    // Cost of comparing two slices of host memory
-    HostMemCmp = 4,
+    // Cost of allocating a slice of memory (in bytes)
+    MemAlloc = 1,
+    // Cost of copying a slice of bytes into a pre-allocated memory
+    MemCpy = 2,
+    // Cost of comparing two slices of memory
+    MemCmp = 3,
     // Cost of a host function dispatch, not including the actual work done by
     // the function nor the cost of VM invocation machinary
-    DispatchHostFunction = 5,
+    DispatchHostFunction = 4,
     // Cost of visiting a host object from the host object storage. Exists to 
     // make sure some baseline cost coverage, i.e. repeatly visiting objects
     // by the guest will always incur some charges.
-    VisitObject = 6,
+    VisitObject = 5,
     // Cost of serializing an xdr object to bytes
-    ValSer = 7,
+    ValSer = 6,
     // Cost of deserializing an xdr object from bytes
-    ValDeser = 8,
+    ValDeser = 7,
     // Cost of computing the sha256 hash from bytes
-    ComputeSha256Hash = 9,
+    ComputeSha256Hash = 8,
     // Cost of computing the ed25519 pubkey from bytes
-    ComputeEd25519PubKey = 10,
-    // Cost of accessing an entry in a Map.
-    MapEntry = 11,
-    // Cost of accessing an entry in a Vec
-    VecEntry = 12,
+    ComputeEd25519PubKey = 9,
     // Cost of verifying ed25519 signature of a payload.
-    VerifyEd25519Sig = 13,
-    // Cost of reading a slice of vm linear memory
-    VmMemRead = 14,
-    // Cost of writing to a slice of vm linear memory
-    VmMemWrite = 15,
+    VerifyEd25519Sig = 10,
     // Cost of instantiation a VM from wasm bytes code.
-    VmInstantiation = 16,
+    VmInstantiation = 11,
     // Cost of instantiation a VM from a cached state.
-    VmCachedInstantiation = 17,
+    VmCachedInstantiation = 12,
     // Cost of invoking a function on the VM. If the function is a host function,
     // additional cost will be covered by `DispatchHostFunction`.
-    InvokeVmFunction = 18,
+    InvokeVmFunction = 13,
     // Cost of computing a keccak256 hash from bytes.
-    ComputeKeccak256Hash = 19,
-    // Cost of computing an ECDSA secp256k1 pubkey from bytes.
-    ComputeEcdsaSecp256k1Key = 20,
+    ComputeKeccak256Hash = 14,
     // Cost of computing an ECDSA secp256k1 signature from bytes.
-    ComputeEcdsaSecp256k1Sig = 21,
+    ComputeEcdsaSecp256k1Sig = 15,
     // Cost of recovering an ECDSA secp256k1 key from a signature.
-    RecoverEcdsaSecp256k1Key = 22,
+    RecoverEcdsaSecp256k1Key = 16,
     // Cost of int256 addition (`+`) and subtraction (`-`) operations
-    Int256AddSub = 23,
+    Int256AddSub = 17,
     // Cost of int256 multiplication (`*`) operation
-    Int256Mul = 24,
+    Int256Mul = 18,
     // Cost of int256 division (`/`) operation
-    Int256Div = 25,
+    Int256Div = 19,
     // Cost of int256 power (`exp`) operation
-    Int256Pow = 26,
+    Int256Pow = 20,
     // Cost of int256 shift (`shl`, `shr`) operation
-    Int256Shift = 27,
+    Int256Shift = 21,
     // Cost of drawing random bytes using a ChaCha20 PRNG
-    ChaCha20DrawBytes = 28
+    ChaCha20DrawBytes = 22
 };
 
 struct ContractCostParamEntry {


### PR DESCRIPTION
- Remove `WasmMemAlloc` (see [comment](https://github.com/stellar/rs-soroban-env/issues/1020#issuecomment-1754018468))
- Consolidate various memory cost types (see [comment](https://github.com/stellar/rs-soroban-env/issues/1020#issuecomment-1749621087))
- Rename `HostMemXX` to just `MemXX`, all memory accounting occurs on the host side 
- Remove `ComputeEcdsaSecp256k1Key` (https://github.com/stellar/rs-soroban-env/issues/1087)
