### PR TITLE
Added bucketListWindowSamplePeriod config setting

### DIFF
--- a/Stellar-contract-config-setting.x
+++ b/Stellar-contract-config-setting.x
@@ -165,8 +165,11 @@ struct StateArchivalSettings {
     // Number of snapshots to use when calculating average BucketList size
     uint32 bucketListSizeWindowSampleSize;
 
+    // How often to sample the BucketList size for the average, in ledgers
+    uint32 bucketListWindowSamplePeriod;
+
     // Maximum number of bytes that we scan for eviction per ledger
-    uint64 evictionScanSize;
+    uint32 evictionScanSize;
 
     // Lowest BucketList level to be scanned to evict entries
     uint32 startingEvictionScanLevel;


### PR DESCRIPTION
This change add the `bucketListWindowSamplePeriod` State Archival network config parameter. While this is technically a protocol breaking XDR change, since this changes a single uint64 value to two uin32 values, the binary structure is identical. Since only core reads this particular value, and since the binary structure is identical so as to not have decoding errors between the two versions, down stream systems should not have to pick up this change to be compatible with protocol 20.