### PR TITLE
Add Soroban write fee to LCM.

### DIFF
--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -484,11 +484,22 @@ struct LedgerCloseMetaV0
     SCPHistoryEntry scpInfo<>;
 };
 
+struct LedgerCloseMetaExtV1
+{
+    int64 sorobanFeeWrite1KB;
+};
+
+union LedgerCloseMetaExt switch (int v)
+{
+case 0:
+    void;
+case 1:
+    LedgerCloseMetaExtV1 v1;
+};
+
 struct LedgerCloseMetaV1
 {
-    // We forgot to add an ExtensionPoint in v0 but at least
-    // we can add one now in v1.
-    ExtensionPoint ext;
+    LedgerCloseMetaExt ext;
 
     LedgerHeaderHistoryEntry ledgerHeader;
 

--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -486,6 +486,7 @@ struct LedgerCloseMetaV0
 
 struct LedgerCloseMetaExtV1
 {
+    ExtensionPoint ext;
     int64 sorobanFeeWrite1KB;
 };
 


### PR DESCRIPTION
Write fee is pretty hard/error-prone to compute manually, so it's easier to just export it. This also automatically supports users in case if the underlying write fee math changes.

This is necessary work as a part of https://github.com/stellar/stellar-core/issues/4244.