### PR TITLE
Add detailed Soroban resource fee info in txmeta

### DIFF
--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -400,9 +400,51 @@ struct DiagnosticEvent
     ContractEvent event;
 };
 
-struct SorobanTransactionMeta 
+struct SorobanTransactionMetaExtV1
 {
     ExtensionPoint ext;
+
+    // The following are the components of the overall Soroban resource fee
+    // charged for the transaction.
+    // The following relation holds:
+    // `resourceFeeCharged = totalNonRefundableResourceFeeCharged + totalRefundableResourceFeeCharged`
+    // where `resourceFeeCharged` is the overall fee charged for the 
+    // transaction. Also, `resourceFeeCharged` <= `sorobanData.resourceFee` 
+    // i.e.we never charge more than the declared resource fee.
+    // The inclusion fee for charged the Soroban transaction can be found using 
+    // the following equation:
+    // `result.feeCharged = resourceFeeCharged + inclusionFeeCharged`.
+
+    // Total amount (in stroops) that has been charged for non-refundable
+    // Soroban resources.
+    // Non-refundable resources are charged based on the usage declared in
+    // the transaction envelope (such as `instructions`, `readBytes` etc.) and 
+    // is charged regardless of the success of the transaction.
+    int64 totalNonRefundableResourceFeeCharged;
+    // Total amount (in stroops) that has been charged for refundable
+    // Soroban resource fees.
+    // Currently this comprises the rent fee (`rentFeeCharged`) and the
+    // fee for the events and return value.
+    // Refundable resources are charged based on the actual resources usage.
+    // Since currently refundable resources are only used for the successful
+    // transactions, this will be `0` for failed transactions.
+    int64 totalRefundableResourceFeeCharged;
+    // Amount (in stroops) that has been charged for rent.
+    // This is a part of `totalNonRefundableResourceFeeCharged`.
+    int64 rentFeeCharged;
+};
+
+union SorobanTransactionMetaExt switch (int v)
+{
+case 0:
+    void;
+case 1:
+    SorobanTransactionMetaExtV1 v1;
+};
+
+struct SorobanTransactionMeta 
+{
+    SorobanTransactionMetaExt ext;
 
     ContractEvent events<>;             // custom events populated by the
                                         // contracts themselves.


### PR DESCRIPTION
While it's in theory possible to compute the non-refundable and rent fee portions of the resource fee using the transaction and ledger diffs, it's way too cumbersome (especially in the rent fee case, as it requires evaluating all the ledger entry diffs). 
This data also allows to compute the Soroban inclusion fee with simple math (`feeCharged - nonRefundableFee - refundableFee`).

Besides addressing some concerns raised https://github.com/stellar/stellar-core/issues/4245, this also may be useful to the end user.