### PR TITLE
Add an XDR type for DiagnosticEvent<>

### DIFF
--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -400,6 +400,8 @@ struct DiagnosticEvent
     ContractEvent event;
 };
 
+typedef DiagnosticEvent DiagnosticEvents<>;
+
 struct SorobanTransactionMetaExtV1
 {
     ExtensionPoint ext;


### PR DESCRIPTION
### What
Add an XDR type DiagnosticEvents for DiagnosticEvent<>.

### Why
Stellar-core returns a variable length array of diagnostic events from it's submission endpoint. It'd be convenient to be able to decode it on the command line with the CLI. We could add the ability to decode arbitrary arrays and other types to the CLI, but that's much more effort and adding a type definition for a type that stellar-core does output is easier and maybe the "right" way to do this anyway.

Supersedes:
- https://github.com/stellar/rs-stellar-xdr/pull/366