### PR TITLE
Revert "Add an XDR type for DiagnosticEvent<> (#187)"

### DIFF
--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -400,8 +400,6 @@ struct DiagnosticEvent
     ContractEvent event;
 };
 
-typedef DiagnosticEvent DiagnosticEvents<>;
-
 struct SorobanTransactionMetaExtV1
 {
     ExtensionPoint ext;


### PR DESCRIPTION
This reverts commit 3adee2d582668531fce8a14067fdd82782cd4d58.

Temporarily reverting this commit so we can pull the updated overlay definitions into stellar-core without revving other dependencies.