### PR TITLE
Reapply "Add an XDR type for DiagnosticEvent<> (#187)" (#188)

### DIFF
--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -400,6 +400,8 @@ struct DiagnosticEvent
     ContractEvent event;
 };
 
+typedef DiagnosticEvent DiagnosticEvents<>;
+
 struct SorobanTransactionMetaExtV1
 {
     ExtensionPoint ext;


### PR DESCRIPTION
This reverts commit f5904cb0639118bf8c41337e7178869ddd0d728b.

Bringing `Stellar-ledger.x` changes back in.