### PR TITLE
Initial XDR definitions for the parallel execution of tx sets.

### DIFF
--- a/Stellar-contract-config-setting.x
+++ b/Stellar-contract-config-setting.x
@@ -23,6 +23,18 @@ struct ConfigSettingContractComputeV0
     uint32 txMemoryLimit;
 };
 
+// Settings for running the contract transactions in parallel.
+struct ConfigSettingContractParallelComputeV0
+{
+    // Maximum number of threads that can be used to apply a
+    // transaction set to close the ledger.
+    // This doesn't limit or defined the actual number of 
+    // threads used and instead only defines the minimum number
+    // of physical threads that a tier-1 validator has to support
+    // in order to not fall out of sync with the network.
+    int64 ledgerMaxParallelThreads;
+};
+
 // Ledger access settings for contracts.
 struct ConfigSettingContractLedgerCostV0
 {

--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -201,6 +201,16 @@ enum TxSetComponentType
   TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE = 0
 };
 
+typedef TransactionEnvelope DependentTxCluster<>;
+typedef DependentTxCluster TxExecutionThread<>;
+typedef TxExecutionThread ParallelTxExecutionStage<>;
+
+struct ParallelTxsComponent
+{
+  int64* baseFee;
+  ParallelTxExecutionStage executionStages<>;
+};
+
 union TxSetComponent switch (TxSetComponentType type)
 {
 case TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE:
@@ -215,6 +225,8 @@ union TransactionPhase switch (int v)
 {
 case 0:
     TxSetComponent v0Components<>;
+case 1:
+    ParallelTxsComponent parallelTxsComponent;
 };
 
 // Transaction sets are the unit used by SCP to decide on transitions


### PR DESCRIPTION
There were a few extension possibilities for the tx set; I've chosen extending the phase after experimenting with the implementation. Introducing e.g. a new component is not necessarily wrong, but that does make the tx set building and validation unnecessarily cumbersome. I also don't anticipate allowing multiple parallel components at this moment; even if we want to allow multiple base fees, these should go into the internal structure as the current structure controls the application order.