### PR TITLE
Remove 'cluster' grouping of transactions in parallel stage.

### DIFF
--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -201,8 +201,7 @@ enum TxSetComponentType
   TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE = 0
 };
 
-typedef TransactionEnvelope DependentTxCluster<>;
-typedef DependentTxCluster TxExecutionThread<>;
+typedef TransactionEnvelope TxExecutionThread<>;
 typedef TxExecutionThread ParallelTxExecutionStage<>;
 
 struct ParallelTxsComponent


### PR DESCRIPTION
It doesn't provide that much benefit as we can infer the clusters from the thread transactions quickly if necessary.