### PR TITLE
Remove proofs from SorobanTransactionData

### DIFF
--- a/Stellar-ledger-entries.x
+++ b/Stellar-ledger-entries.x
@@ -678,7 +678,6 @@ enum EnvelopeType
     ENVELOPE_TYPE_CONTRACT_ID = 8,
     ENVELOPE_TYPE_SOROBAN_AUTHORIZATION = 9
 };
-}
 
 enum BucketListType
 {
@@ -795,3 +794,4 @@ case COLD_ARCHIVE_BOUNDARY_LEAF:
 case COLD_ARCHIVE_HASH:
     ColdArchiveHashEntry hashEntry;
 };
+}

--- a/Stellar-transaction.x
+++ b/Stellar-transaction.x
@@ -883,13 +883,7 @@ struct SorobanResources
 // The transaction extension for Soroban.
 struct SorobanTransactionData
 {
-    union switch (int v)
-    {
-    case 0:
-        void;
-    case 1:
-        ArchivalProof proofs<>;
-    } ext;
+    ExtensionPoint ext;
     SorobanResources resources;
     // Amount of the transaction `fee` allocated to the Soroban resource fees.
     // The fraction of `resourceFee` corresponding to `resources` specified 


### PR DESCRIPTION
Since State Archival has been pushed to p23, this removes the public facing XDR changes from `curr`