### PR TITLE
Split the interface version into protocol and pre-release-version (next)

### DIFF
--- a/Stellar-contract-env-meta.x
+++ b/Stellar-contract-env-meta.x
@@ -17,7 +17,10 @@ enum SCEnvMetaKind
 union SCEnvMetaEntry switch (SCEnvMetaKind kind)
 {
 case SC_ENV_META_KIND_INTERFACE_VERSION:
-    uint64 interfaceVersion;
+    struct {
+        uint32 protocol;
+        uint32 preRelease;
+    } interfaceVersion;
 };
 
 }


### PR DESCRIPTION
### What
Split the 64bit interface version field in the env meta into two separate fields for the data it contains.

### Why
See:
- https://github.com/stellar/stellar-xdr/pull/212