### PR TITLE
bls12-381 cost type: split on-curve and in-subgroup check

### DIFF
--- a/Stellar-contract-config-setting.x
+++ b/Stellar-contract-config-setting.x
@@ -194,48 +194,52 @@ enum ContractCostType {
     Bls12381EncodeFp = 45,
     // Cost of decoding a BLS12-381 Fp (base field element)
     Bls12381DecodeFp = 46,
-    // Cost of validating a G1 point lies on the curve and belongs to the correct subgroup
-    Bls12381G1Validate = 47,
-    // Cost of validating a G2 point lies on the curve and belongs to the correct subgroup
-    Bls12381G2Validate = 48,
+    // Cost of checking a G1 point lies on the curve
+    Bls12381G1CheckPointOnCurve = 47,
+    // Cost of checking a G1 point belongs to the correct subgroup
+    Bls12381G1CheckPointInSubgroup = 48,
+    // Cost of checking a G2 point lies on the curve
+    Bls12381G2CheckPointOnCurve = 49,
+    // Cost of checking a G2 point belongs to the correct subgroup
+    Bls12381G2CheckPointInSubgroup = 50,
     // Cost of converting a BLS12-381 G1 point from projective to affine coordinates
-    Bls12381G1ProjectiveToAffine = 49,
+    Bls12381G1ProjectiveToAffine = 51,
     // Cost of converting a BLS12-381 G2 point from projective to affine coordinates
-    Bls12381G2ProjectiveToAffine = 50,
+    Bls12381G2ProjectiveToAffine = 52,
     // Cost of performing BLS12-381 G1 point addition
-    Bls12381G1Add = 51,
+    Bls12381G1Add = 53,
     // Cost of performing BLS12-381 G1 scalar multiplication
-    Bls12381G1Mul = 52,
+    Bls12381G1Mul = 54,
     // Cost of performing BLS12-381 G1 multi-scalar multiplication (MSM)
-    Bls12381G1Msm = 53,
+    Bls12381G1Msm = 55,
     // Cost of mapping a BLS12-381 Fp field element to a G1 point
-    Bls12381MapFpToG1 = 54,
+    Bls12381MapFpToG1 = 56,
     // Cost of hashing to a BLS12-381 G1 point
-    Bls12381HashToG1 = 55,
+    Bls12381HashToG1 = 57,
     // Cost of performing BLS12-381 G2 point addition
-    Bls12381G2Add = 56,
+    Bls12381G2Add = 58,
     // Cost of performing BLS12-381 G2 scalar multiplication
-    Bls12381G2Mul = 57,
+    Bls12381G2Mul = 59,
     // Cost of performing BLS12-381 G2 multi-scalar multiplication (MSM)
-    Bls12381G2Msm = 58,
+    Bls12381G2Msm = 60,
     // Cost of mapping a BLS12-381 Fp2 field element to a G2 point
-    Bls12381MapFp2ToG2 = 59,
+    Bls12381MapFp2ToG2 = 61,
     // Cost of hashing to a BLS12-381 G2 point
-    Bls12381HashToG2 = 60,
+    Bls12381HashToG2 = 62,
     // Cost of performing BLS12-381 pairing operation
-    Bls12381Pairing = 61,
+    Bls12381Pairing = 63,
     // Cost of converting a BLS12-381 scalar element from U256
-    Bls12381FrFromU256 = 62,
+    Bls12381FrFromU256 = 64,
     // Cost of converting a BLS12-381 scalar element to U256
-    Bls12381FrToU256 = 63,
+    Bls12381FrToU256 = 65,
     // Cost of performing BLS12-381 scalar element addition/subtraction
-    Bls12381FrAddSub = 64,
+    Bls12381FrAddSub = 66,
     // Cost of performing BLS12-381 scalar element multiplication
-    Bls12381FrMul = 65,
+    Bls12381FrMul = 67,
     // Cost of performing BLS12-381 scalar element exponentiation
-    Bls12381FrPow = 66,
+    Bls12381FrPow = 68,
     // Cost of performing BLS12-381 scalar element inversion
-    Bls12381FrInv = 67
+    Bls12381FrInv = 69
 };
 
 struct ContractCostParamEntry {


### PR DESCRIPTION
split out cost type for point validation into check-on-curve and check-in-subgroup. 
context:  https://discord.com/channels/897514728459468821/1273320096290570315/1283227010537361481