### PR TITLE
Rename `TxExecutionThread` to `DependentTxCluster`.

### DIFF
--- a/Stellar-contract-config-setting.x
+++ b/Stellar-contract-config-setting.x
@@ -26,13 +26,11 @@ struct ConfigSettingContractComputeV0
 // Settings for running the contract transactions in parallel.
 struct ConfigSettingContractParallelComputeV0
 {
-    // Maximum number of threads that can be used to apply a
-    // transaction set to close the ledger.
-    // This doesn't limit or defined the actual number of 
-    // threads used and instead only defines the minimum number
-    // of physical threads that a tier-1 validator has to support
-    // in order to not fall out of sync with the network.
-    uint32 ledgerMaxParallelThreads;
+    // Maximum number of clusters with dependent transactions allowed in a
+    // stage of parallel tx set component.
+    // This effectively sets the lower bound on the number of physical threads
+    // necessary to effectively apply transaction sets in parallel.
+    uint32 ledgerMaxDependentTxClusters;
 };
 
 // Ledger access settings for contracts.

--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -164,12 +164,30 @@ enum TxSetComponentType
   TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE = 0
 };
 
-typedef TransactionEnvelope TxExecutionThread<>;
-typedef TxExecutionThread ParallelTxExecutionStage<>;
+// A collection of transactions that *may* have arbitrary read-write data
+// dependencies between each other, i.e. in a general case the transaction
+// execution order within a cluster may not be arbitrarily shuffled without
+// affecting the end result.
+typedef TransactionEnvelope DependentTxCluster<>;
+// A collection of clusters such that are *guaranteed* to not have read-write 
+// data dependencies in-between clusters, i.e. such that the cluster execution 
+// order can be arbitrarily shuffled without affecting the end result. Thus
+// clusters can be executed in parallel with respect to each other.
+typedef DependentTxCluster ParallelTxExecutionStage<>;
 
+// Transaction set component that contains transactions organized in a 
+// parallelism-friendly fashion.
+//
+// The component consists of several stages that have to be executed in 
+// sequential order, each stage consists of several clusters that can be 
+// executed in parallel, and the cluster itself consists of several 
+// transactions that have to be executed in sequential order in a general case.
 struct ParallelTxsComponent
 {
   int64* baseFee;
+  // A sequence of stages that *may* have arbitrary data dependencies between
+  // each other, i.e. in a general case the stage execution order may not be
+  // arbitrarily shuffled without affecting the end result.
   ParallelTxExecutionStage executionStages<>;
 };
 


### PR DESCRIPTION
This is a bit more generic and doesn't suggest the exact execution model (protocol technically allows multiple clusters to be executed sequentially, or a single cluster to be executed via multiple threads).

Also added some comments.