### PR TITLE
Cap 66 next

### DIFF
--- a/Stellar-ledger-entries.x
+++ b/Stellar-ledger-entries.x
@@ -683,8 +683,7 @@ enum EnvelopeType
 enum BucketListType
 {
     LIVE = 0,
-    HOT_ARCHIVE = 1,
-    COLD_ARCHIVE = 2
+    HOT_ARCHIVE = 1
 };
 
 /* Entries used to define the bucket list */

--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -527,27 +527,12 @@ struct LedgerCloseMetaExtV1
     int64 sorobanFeeWrite1KB;
 };
 
-struct LedgerCloseMetaExtV2
-{
-    ExtensionPoint ext;
-    int64 sorobanFeeWrite1KB;
-
-    uint32 currentArchivalEpoch;
-
-    // The last epoch currently stored by validators
-    // Any entry restored from an epoch older than this will
-    // require a proof.
-    uint32 lastArchivalEpochPersisted;
-};
-
 union LedgerCloseMetaExt switch (int v)
 {
 case 0:
     void;
 case 1:
     LedgerCloseMetaExtV1 v1;
-case 2:
-    LedgerCloseMetaExtV2 v2;
 };
 
 struct LedgerCloseMetaV1

--- a/Stellar-transaction.x
+++ b/Stellar-transaction.x
@@ -848,56 +848,6 @@ struct LedgerFootprint
     LedgerKey readWrite<>;
 };
 
-enum ArchivalProofType
-{
-    EXISTENCE = 0,
-    NONEXISTENCE = 1
-};
-
-struct ArchivalProofNode
-{
-    uint32 index;
-    Hash hash;
-};
-
-typedef ArchivalProofNode ProofLevel<>;
-
-struct ExistenceProofBody
-{
-    ColdArchiveBucketEntry entriesToProve<>;
-
-    // Vector of vectors, where proofLevels[level]
-    // contains all HashNodes that correspond with that level
-    ProofLevel proofLevels<>;
-};
-
-struct NonexistenceProofBody
-{
-    LedgerKey keysToProve<>;
-
-    // Bounds for each key being proved, where bound[n]
-    // corresponds to keysToProve[n]
-    ColdArchiveBucketEntry lowBoundEntries<>;
-    ColdArchiveBucketEntry highBoundEntries<>;
-
-    // Vector of vectors, where proofLevels[level]
-    // contains all HashNodes that correspond with that level
-    ProofLevel proofLevels<>;
-};
-
-struct ArchivalProof
-{
-    uint32 epoch; // AST Subtree for this proof
-
-    union switch (ArchivalProofType t)
-    {
-    case NONEXISTENCE:
-        NonexistenceProofBody nonexistenceProof;
-    case EXISTENCE:
-        ExistenceProofBody existenceProof;
-    } body;
-};
-
 // Resource limits for a Soroban transaction.
 // The transaction will fail if it exceeds any of these limits.
 struct SorobanResources

--- a/Stellar-transaction.x
+++ b/Stellar-transaction.x
@@ -863,6 +863,14 @@ struct SorobanResources
     uint32 writeBytes;
 };
 
+struct SorobanResourcesExtV0
+{
+    // Vector of indices representing what Soroban
+    // entries in the footprint are archived, based on the
+    // order of keys provided in the readWrite footprint.
+    uint32 archivedSorobanEntries<>;
+};
+
 // The transaction extension for Soroban.
 struct SorobanTransactionData
 {
@@ -871,7 +879,7 @@ struct SorobanTransactionData
     case 0:
         void;
     case 1:
-        ArchivalProof proofs<>;
+        SorobanResourcesExtV0 resourceExt;
     } ext;
     SorobanResources resources;
     // Amount of the transaction `fee` allocated to the Soroban resource fees.


### PR DESCRIPTION
Removes proofs and cold archive structs from next.

Additionally, adds `archivedSorobanEntries` for CAP 66. While CAP 66 has other XDR changes as well, these are all renames that will be done after the next core release so that we can do them in both next and curr at the same time to avoid messy ifdefs.