### PR TITLE
Remove support for old survey mechanism (next)

### DIFF
--- a/Stellar-overlay.x
+++ b/Stellar-overlay.x
@@ -112,6 +112,9 @@ enum MessageType
     // new messages
     HELLO = 13,
 
+    // SURVEY_REQUEST (14) removed and replaced by TIME_SLICED_SURVEY_REQUEST
+    // SURVEY_RESPONSE (15) removed and replaced by TIME_SLICED_SURVEY_RESPONSE
+
     SEND_MORE = 16,
     SEND_MORE_EXTENDED = 20,
 

--- a/Stellar-overlay.x
+++ b/Stellar-overlay.x
@@ -112,9 +112,6 @@ enum MessageType
     // new messages
     HELLO = 13,
 
-    SURVEY_REQUEST = 14,
-    SURVEY_RESPONSE = 15,
-
     SEND_MORE = 16,
     SEND_MORE_EXTENDED = 20,
 
@@ -135,14 +132,11 @@ struct DontHave
 
 enum SurveyMessageCommandType
 {
-    SURVEY_TOPOLOGY = 0,
     TIME_SLICED_SURVEY_TOPOLOGY = 1
 };
 
 enum SurveyMessageResponseType
 {
-    SURVEY_TOPOLOGY_RESPONSE_V0 = 0,
-    SURVEY_TOPOLOGY_RESPONSE_V1 = 1,
     SURVEY_TOPOLOGY_RESPONSE_V2 = 2
 };
 
@@ -189,12 +183,6 @@ struct TimeSlicedSurveyRequestMessage
     uint32 outboundPeersIndex;
 };
 
-struct SignedSurveyRequestMessage
-{
-    Signature requestSignature;
-    SurveyRequestMessage request;
-};
-
 struct SignedTimeSlicedSurveyRequestMessage
 {
     Signature requestSignature;
@@ -215,12 +203,6 @@ struct TimeSlicedSurveyResponseMessage
 {
     SurveyResponseMessage response;
     uint32 nonce;
-};
-
-struct SignedSurveyResponseMessage
-{
-    Signature responseSignature;
-    SurveyResponseMessage response;
 };
 
 struct SignedTimeSlicedSurveyResponseMessage
@@ -250,8 +232,6 @@ struct PeerStats
     uint64 duplicateFetchMessageRecv;
 };
 
-typedef PeerStats PeerStatList<25>;
-
 struct TimeSlicedNodeData
 {
     uint32 addedAuthenticatedPeers;
@@ -280,27 +260,6 @@ struct TimeSlicedPeerData
 
 typedef TimeSlicedPeerData TimeSlicedPeerDataList<25>;
 
-struct TopologyResponseBodyV0
-{
-    PeerStatList inboundPeers;
-    PeerStatList outboundPeers;
-
-    uint32 totalInboundPeerCount;
-    uint32 totalOutboundPeerCount;
-};
-
-struct TopologyResponseBodyV1
-{
-    PeerStatList inboundPeers;
-    PeerStatList outboundPeers;
-
-    uint32 totalInboundPeerCount;
-    uint32 totalOutboundPeerCount;
-
-    uint32 maxInboundPeerCount;
-    uint32 maxOutboundPeerCount;
-};
-
 struct TopologyResponseBodyV2
 {
     TimeSlicedPeerDataList inboundPeers;
@@ -310,10 +269,6 @@ struct TopologyResponseBodyV2
 
 union SurveyResponseBody switch (SurveyMessageResponseType type)
 {
-case SURVEY_TOPOLOGY_RESPONSE_V0:
-    TopologyResponseBodyV0 topologyResponseBodyV0;
-case SURVEY_TOPOLOGY_RESPONSE_V1:
-    TopologyResponseBodyV1 topologyResponseBodyV1;
 case SURVEY_TOPOLOGY_RESPONSE_V2:
     TopologyResponseBodyV2 topologyResponseBodyV2;
 };
@@ -356,12 +311,6 @@ case GENERALIZED_TX_SET:
 
 case TRANSACTION:
     TransactionEnvelope transaction;
-
-case SURVEY_REQUEST:
-    SignedSurveyRequestMessage signedSurveyRequestMessage;
-
-case SURVEY_RESPONSE:
-    SignedSurveyResponseMessage signedSurveyResponseMessage;
 
 case TIME_SLICED_SURVEY_REQUEST:
     SignedTimeSlicedSurveyRequestMessage signedTimeSlicedSurveyRequestMessage;


### PR DESCRIPTION
This change removes all message types used in the old survey mechanism. This is required to support https://github.com/stellar/stellar-core/issues/4332.