### PR TITLE
Revert "Remove ColdArchive and proof structs (#232)"

### DIFF
--- a/Stellar-ledger-entries.x
+++ b/Stellar-ledger-entries.x
@@ -682,7 +682,8 @@ enum EnvelopeType
 enum BucketListType
 {
     LIVE = 0,
-    HOT_ARCHIVE = 1
+    HOT_ARCHIVE = 1,
+    COLD_ARCHIVE = 2
 };
 
 /* Entries used to define the bucket list */

--- a/Stellar-transaction.x
+++ b/Stellar-transaction.x
@@ -823,6 +823,56 @@ struct LedgerFootprint
     LedgerKey readWrite<>;
 };
 
+enum ArchivalProofType
+{
+    EXISTENCE = 0,
+    NONEXISTENCE = 1
+};
+
+struct ArchivalProofNode
+{
+    uint32 index;
+    Hash hash;
+};
+
+typedef ArchivalProofNode ProofLevel<>;
+
+struct NonexistenceProofBody
+{
+    ColdArchiveBucketEntry entriesToProve<>;
+
+    // Vector of vectors, where proofLevels[level]
+    // contains all HashNodes that correspond with that level
+    ProofLevel proofLevels<>;
+};
+
+struct ExistenceProofBody
+{
+    LedgerKey keysToProve<>;
+
+    // Bounds for each key being proved, where bound[n]
+    // corresponds to keysToProve[n]
+    ColdArchiveBucketEntry lowBoundEntries<>;
+    ColdArchiveBucketEntry highBoundEntries<>;
+
+    // Vector of vectors, where proofLevels[level]
+    // contains all HashNodes that correspond with that level
+    ProofLevel proofLevels<>;
+};
+
+struct ArchivalProof
+{
+    uint32 epoch; // AST Subtree for this proof
+
+    union switch (ArchivalProofType t)
+    {
+    case EXISTENCE:
+        NonexistenceProofBody nonexistenceProof;
+    case NONEXISTENCE:
+        ExistenceProofBody existenceProof;
+    } body;
+};
+
 // Resource limits for a Soroban transaction.
 // The transaction will fail if it exceeds any of these limits.
 struct SorobanResources


### PR DESCRIPTION
This reverts commit 63d87bbb388c964a9cc758397677ac2d6951c342.

Reverting this commit to resolve an XDR hash mismatch between core and env for the 22.2 release.