### PR TITLE
Add TransactionResultMetaV1 and LedgerCloseMetaV2

### DIFF
--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -506,7 +506,7 @@ struct TransactionResultMetaV1
     LedgerEntryChanges feeProcessing;
     TransactionMeta txApplyProcessing;
 
-    LedgerEntryChanges postTxApplyProcessing;
+    LedgerEntryChanges postTxApplyFeeProcessing;
 };
 
 // this represents a single upgrade that was performed as part of a ledger

--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -488,7 +488,7 @@ case 3:
 // This struct groups together changes on a per transaction basis
 // note however that fees and transaction application are done in separate
 // phases
-struct TransactionResultMetaV0
+struct TransactionResultMeta
 {
     TransactionResultPair result;
     LedgerEntryChanges feeProcessing;
@@ -526,7 +526,7 @@ struct LedgerCloseMetaV0
     // NB: transactions are sorted in apply order here
     // fees for all transactions are processed first
     // followed by applying transactions
-    TransactionResultMetaV0 txProcessing<>;
+    TransactionResultMeta txProcessing<>;
 
     // upgrades are applied last
     UpgradeEntryMeta upgradesProcessing<>;
@@ -560,7 +560,7 @@ struct LedgerCloseMetaV1
     // NB: transactions are sorted in apply order here
     // fees for all transactions are processed first
     // followed by applying transactions
-    TransactionResultMetaV0 txProcessing<>;
+    TransactionResultMeta txProcessing<>;
 
     // upgrades are applied last
     UpgradeEntryMeta upgradesProcessing<>;


### PR DESCRIPTION
What it would look like if we were to add a `postTxApplyProcessing` portion of meta. This is the xdr change for one of the solutions for dealing with fee refunds in parallel soroban.