### PR TITLE
Remove op level diagnostic events for CAP-0067

### DIFF
--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -441,7 +441,6 @@ struct OperationMetaV2
     LedgerEntryChanges changes;
 
     ContractEvent events<>;
-    DiagnosticEvent diagnosticEvents<>;
 };
 
 struct SorobanTransactionMetaV2
@@ -464,8 +463,7 @@ struct TransactionMetaV4
                                            // Soroban transactions).
 
     ContractEvent events<>; // Used for transaction-level events (like fee payment)
-    DiagnosticEvent txDiagnosticEvents<>; // Used for transaction-level diagnostic
-                                          //  information
+    DiagnosticEvent diagnosticEvents<>; // Used for all diagnostic information
 };
 
 


### PR DESCRIPTION
Xdr change for https://github.com/stellar/stellar-protocol/pull/1685.

I'll open the PR in next once this is merged.