### PR TITLE
Wrap contract id hash values in a nominal type (next)

### DIFF
--- a/Stellar-contract.x
+++ b/Stellar-contract.x
@@ -196,7 +196,7 @@ union SCAddress switch (SCAddressType type)
 case SC_ADDRESS_TYPE_ACCOUNT:
     AccountID accountId;
 case SC_ADDRESS_TYPE_CONTRACT:
-    Hash contractId;
+    ContractID contractId;
 case SC_ADDRESS_TYPE_MUXED_ACCOUNT:
     MuxedEd25519Account muxedAccount;
 case SC_ADDRESS_TYPE_CLAIMABLE_BALANCE:

--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -128,7 +128,7 @@ enum LedgerUpgradeType
 };
 
 struct ConfigUpgradeSetKey {
-    Hash contractID;
+    ContractID contractID;
     Hash contentHash;
 };
 
@@ -374,7 +374,7 @@ struct ContractEvent
     // is first, to change ContractEvent into a union.
     ExtensionPoint ext;
 
-    Hash* contractID;
+    ContractID* contractID;
     ContractEventType type;
 
     union switch (int v)

--- a/Stellar-types.x
+++ b/Stellar-types.x
@@ -84,6 +84,8 @@ typedef opaque SignatureHint[4];
 typedef PublicKey NodeID;
 typedef PublicKey AccountID;
 
+typedef Hash ContractID;
+
 struct Curve25519Secret
 {
     opaque key[32];


### PR DESCRIPTION
### What
Wrap contract id hash values in a type naming the type of value contract id.

### Why
Same change for `next` as was merged for `curr` in:
- https://github.com/stellar/stellar-xdr/pull/250