### PR TITLE
Add SorobanAuthorizationEntries typedef

### DIFF
--- a/Stellar-transaction.x
+++ b/Stellar-transaction.x
@@ -594,6 +594,8 @@ struct SorobanAuthorizationEntry
     SorobanAuthorizedInvocation rootInvocation;
 };
 
+typedef SorobanAuthorizationEntry SorobanAuthorizationEntries<>;
+
 /* Upload Wasm, create, and invoke contracts in Soroban.
 
     Threshold: med


### PR DESCRIPTION
[SEP-45](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0045.md), the web authentication protocol for contract accounts [encodes its challenge authorization entries](https://lab.stellar.org/xdr/view?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&xdr$blob=AAAAAQAAAAGWcNI4dwOklpzAc0hlSYazv+tjfedqewN928nnaj1h9mdGTObL5paKAAAAAAAAAAEAAAAAAAAAAZ772JA0Yoyrj61SFsabc9PKM1//yhpd9BlEdlU3DXUXXAAAAD3dlYl9hdXRoX3ZlcmlmeQAAAAABAAAAEQAAAAEAAAAFAAAADwAAAAdhY2NvdW50AAAAAA4AAAA4Q0NMSEJVUllPNEIySkZVNFlCWlVRWktKUTJaMzcyM0RQWFRXVTZZRFBYTjRUWjNLSFZRN05PVUwAAAAPAAAAC2hvbWVfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAA8AAAAFbm9uY2UAAAAAAAAOAAAACjIzMTg0NDg1NjEAAAAAAA8AAAAPd2ViX2F1dGhfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAA8AAAAXd2ViX2F1dGhfZG9tYWluX2FjY291bnQAAAAADgAAADhHQ0hMSERCT0tHMkpXTUpRQlRMU0w1WEc2Tk83RVNYSTJUQVFLWlhDWFdYQjVXSTJYNlcyMzNQUgAAAAAAAAABAAAAAAAAAACOs4wuUbSbMTAM1yX25vNd8kro1MEFZuK9rh7ZGr+trRSX5y0czfjiABlOXQAAABAAAAABAAAAAQAAABEAAAABAAAAAgAAAA8AAAAKcHVibGljX2tleQAAAAAADQAAACCOs4wuUbSbMTAM1yX25vNd8kro1MEFZuK9rh7ZGr+trQAAAA8AAAAJc2lnbmF0dXJlAAAAAAAADQAAAEBtWcnlsiHoLNhWnTo4YvvqrUKrtOvtfGdZhux3uFl1MXKAI4HJvQZzd8TW8y6N5CltNcMibyuLJhjBrtAMGZUPAAAAAAAAAAGe+9iQNGKMq4+tUhbGm3PTyjNf8oaXfQZRHZVNw11F1wAAAA93ZWJfYXV0aF92ZXJpZnkAAAAAAQAAABEAAAABAAAABQAAAA8AAAAHYWNjb3VudAAAAAAOAAAAOENDTEhCVVJZTzRCMkpGVTRZQlpVUVpLSlEyWjM3MjNEUFhUV1U2WURQWE40VFozS0hWUTdOT1VMAAAADwAAAAtob21lX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAABW5vbmNlAAAAAAAADgAAAAoyMzE4NDQ4NTYxAAAAAAAPAAAAD3dlYl9hdXRoX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAAF3dlYl9hdXRoX2RvbWFpbl9hY2NvdW50AAAAAA4AAAA4R0NITEhEQk9LRzJKV01KUUJUTFNMNVhHNk5PN0VTWEkyVEFRS1pYQ1hXWEI1V0kyWDZXMjMzUFIAAAAA&type=SorobanAuthorizationEntry;;) in a single XDR array. This PR adds the SorobanAuthorizationEntries typedef so that the SDKs can easily encode and decode the challenge.
