### PR TITLE
Make return value optional in Soroban meta v2

### DIFF
--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -477,7 +477,7 @@ struct SorobanTransactionMetaV2
 {
     SorobanTransactionMetaExt ext;
 
-    SCVal returnValue;
+    SCVal* returnValue;
 };
 
 struct TransactionMetaV4


### PR DESCRIPTION
Making it non-optional was an oversight; extend TTL and restore ops shouldn't have a return value (currently we end up using the default SCVal, which is `false`).