### PR TITLE
Update SCPQuorumSet documentation

### DIFF
--- a/Stellar-SCP.x
+++ b/Stellar-SCP.x
@@ -75,8 +75,8 @@ struct SCPEnvelope
     Signature signature;
 };
 
-// supports things like: A,B,C,(D,E,F),(G,H,(I,J,K,L))
-// only allows 2 levels of nesting
+// supports things like: A,B,(C,D,E),(F,G,(H,I,(J,K,(L,M))))
+// only allows 4 levels of nesting
 struct SCPQuorumSet
 {
     uint32 threshold;


### PR DESCRIPTION
`SCPQuorumSet` documentation still refers to the old nesting limit of 2—the nesting limit is now 4 (and has been since 2019). See also https://github.com/stellar/stellar-core/issues/4541.