### PR TITLE
Remove limits on sub-items from spec definitions

### DIFF
--- a/Stellar-contract-spec.x
+++ b/Stellar-contract-spec.x
@@ -135,7 +135,7 @@ struct SCSpecUDTStructV0
     string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
     string name<60>;
-    SCSpecUDTStructFieldV0 fields<40>;
+    SCSpecUDTStructFieldV0 fields<>;
 };
 
 struct SCSpecUDTUnionCaseVoidV0
@@ -148,7 +148,7 @@ struct SCSpecUDTUnionCaseTupleV0
 {
     string doc<SC_SPEC_DOC_LIMIT>;
     string name<60>;
-    SCSpecTypeDef type<12>;
+    SCSpecTypeDef type<>;
 };
 
 enum SCSpecUDTUnionCaseV0Kind
@@ -170,7 +170,7 @@ struct SCSpecUDTUnionV0
     string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
     string name<60>;
-    SCSpecUDTUnionCaseV0 cases<50>;
+    SCSpecUDTUnionCaseV0 cases<>;
 };
 
 struct SCSpecUDTEnumCaseV0
@@ -185,7 +185,7 @@ struct SCSpecUDTEnumV0
     string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
     string name<60>;
-    SCSpecUDTEnumCaseV0 cases<50>;
+    SCSpecUDTEnumCaseV0 cases<>;
 };
 
 struct SCSpecUDTErrorEnumCaseV0
@@ -200,7 +200,7 @@ struct SCSpecUDTErrorEnumV0
     string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
     string name<60>;
-    SCSpecUDTErrorEnumCaseV0 cases<50>;
+    SCSpecUDTErrorEnumCaseV0 cases<>;
 };
 
 struct SCSpecFunctionInputV0
@@ -214,7 +214,7 @@ struct SCSpecFunctionV0
 {
     string doc<SC_SPEC_DOC_LIMIT>;
     SCSymbol name;
-    SCSpecFunctionInputV0 inputs<10>;
+    SCSpecFunctionInputV0 inputs<>;
     SCSpecTypeDef outputs<1>;
 };
 
@@ -245,7 +245,7 @@ struct SCSpecEventV0
     string lib<80>;
     SCSymbol name;
     SCSymbol prefixTopics<2>;
-    SCSpecEventParamV0 params<50>;
+    SCSpecEventParamV0 params<>;
     SCSpecEventDataFormat dataFormat;
 };
 


### PR DESCRIPTION
### What
  Remove fixed element limits from UDT struct fields, union cases, enum cases error enum cases, function inputs, and event params, essentially changing the max from the specified maxes to u32::MAX.

  ### Why
  Early on during Soroban's development we set limits on a lot of the new types to make decoding safer. However we quickly discovered that type of limiting was insufficient and we removed the limits and for XDR limits we now instead use some other strategies by measuring bytes and depth. However when we removed the limits from the new contract types we didn't remove the limits from the spec types and they remained. A couple times the limits have caused problems and with the limits being largely arbitrary they should be removed.

Related conversation: https://stellarfoundation.slack.com/archives/C08NEGD4PPG/p1758877637503109

### Merging
This is a non-breaking change with regards to the XDR binary, but it is a breaking change with regards to the Rust library that is generated from the XDR. It's a breaking change because the max limits are encoded into the types via generic parameters. So the safest time to make this change is during the next major version, v24.