### PR TITLE
Fix conflicting comment on rent fee

### DIFF
--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -439,7 +439,7 @@ struct SorobanTransactionMetaExtV1
     // transactions, this will be `0` for failed transactions.
     int64 totalRefundableResourceFeeCharged;
     // Amount (in stroops) that has been charged for rent.
-    // This is a part of `totalNonRefundableResourceFeeCharged`.
+    // This is a part of `totalRefundableResourceFeeCharged`.
     int64 rentFeeCharged;
 };
 


### PR DESCRIPTION
### What

Correct the documentation comment on `rentFeeCharged` in `SorobanTransactionMetaExtV1` so it describes the rent fee as a component of `totalRefundableResourceFeeCharged`.

### Why

The struct contained two comments that contradicted each other: the comment on `totalRefundableResourceFeeCharged` lists the rent fee as one of its components, while the comment on `rentFeeCharged` stated it was part of `totalNonRefundableResourceFeeCharged`. Rent is a refundable Soroban resource that is charged based on actual usage, as documented in the [Stellar fees, resource limits, and metering docs](https://developers.stellar.org/docs/learn/fundamentals/fees-resource-limits-metering), so the comment on `rentFeeCharged` was the incorrect one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnQfKHemzKnr2jAd1NxAR6)_