### PR TITLE
SPIKE: Protocol 28 (CAP-0084)

### DIFF
--- a/Stellar-contract.x
+++ b/Stellar-contract.x
@@ -183,6 +183,10 @@ enum SCAddressType
     SC_ADDRESS_TYPE_MUXED_ACCOUNT = 2,
     SC_ADDRESS_TYPE_CLAIMABLE_BALANCE = 3,
     SC_ADDRESS_TYPE_LIQUIDITY_POOL = 4
+#ifdef CAP_0084
+    ,
+    SC_ADDRESS_TYPE_MUXED_CONTRACT = 5
+#endif
 };
 
 struct MuxedEd25519Account
@@ -190,6 +194,14 @@ struct MuxedEd25519Account
     uint64 id;
     uint256 ed25519;
 };
+
+#ifdef CAP_0084
+struct MuxedContract
+{
+    uint64 id;
+    ContractID contractId;
+};
+#endif
 
 union SCAddress switch (SCAddressType type)
 {
@@ -203,6 +215,10 @@ case SC_ADDRESS_TYPE_CLAIMABLE_BALANCE:
     ClaimableBalanceID claimableBalanceId;
 case SC_ADDRESS_TYPE_LIQUIDITY_POOL:
     PoolID liquidityPoolId;
+#ifdef CAP_0084
+case SC_ADDRESS_TYPE_MUXED_CONTRACT:
+    MuxedContract muxedContract;
+#endif
 };
 
 %struct SCVal;


### PR DESCRIPTION
SPIKE: root of the Protocol 28 / CAP-0084 (muxed contract addresses) stack. This repo is the canonical `.x` source — no upstream to cross-link.

## Changes
- `Stellar-contract.x`: add `SC_ADDRESS_TYPE_MUXED_CONTRACT` arm + `MuxedContract { uint64 id; ContractID contractId; }` struct + `SCAddress` union case, all gated behind `#ifdef CAP_0084` (mirrors `MuxedEd25519Account`).
- Lands in `next` only; `curr` unchanged until core bumps max protocol. `cap_0083` retained — no CAPs dropped this protocol.

## Deferred
- `curr`/`next` regen: handled by the `Generate` workflow on merge to `main` (not committed here).

## Verification
- `make preprocess` with both features → `next` exits 0, emits the 2 + 2 tokens; bare `make preprocess` → `curr` exits 0, 0 tokens.

Upstream: none (canonical source).
Downstream (re-pin to this branch head, each opened by its own pass): rs-stellar-xdr → rs-soroban-env → rs-soroban-sdk → stellar-core → go-stellar-sdk → stellar-horizon → stellar-rpc → js-stellar-base → js-stellar-sdk → js-stellar-xdr-json → stellar-laboratory → docker-stellar-core-horizon.
