### PR TITLE
SPIKE: Protocol 28 (CAP-0084)

### DIFF
--- a/Stellar-contract.x
+++ b/Stellar-contract.x
@@ -183,6 +183,10 @@ enum SCAddressType
     SC_ADDRESS_TYPE_MUXED_ACCOUNT = 2,
     SC_ADDRESS_TYPE_CLAIMABLE_BALANCE = 3,
     SC_ADDRESS_TYPE_LIQUIDITY_POOL = 4
+#ifdef CAP_0084_MUXED_CONTRACT
+    ,
+    SC_ADDRESS_TYPE_MUXED_CONTRACT = 5
+#endif
 };
 
 struct MuxedEd25519Account
@@ -190,6 +194,14 @@ struct MuxedEd25519Account
     uint64 id;
     uint256 ed25519;
 };
+
+#ifdef CAP_0084_MUXED_CONTRACT
+struct MuxedContract
+{
+    uint64 id;
+    ContractID contractId;
+};
+#endif
 
 union SCAddress switch (SCAddressType type)
 {
@@ -203,6 +215,10 @@ case SC_ADDRESS_TYPE_CLAIMABLE_BALANCE:
     ClaimableBalanceID claimableBalanceId;
 case SC_ADDRESS_TYPE_LIQUIDITY_POOL:
     PoolID liquidityPoolId;
+#ifdef CAP_0084_MUXED_CONTRACT
+case SC_ADDRESS_TYPE_MUXED_CONTRACT:
+    MuxedContract muxedContract;
+#endif
 };
 
 %struct SCVal;

--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -439,7 +439,7 @@ struct SorobanTransactionMetaExtV1
     // transactions, this will be `0` for failed transactions.
     int64 totalRefundableResourceFeeCharged;
     // Amount (in stroops) that has been charged for rent.
-    // This is a part of `totalRefundableResourceFeeCharged`.
+    // This is a part of `totalNonRefundableResourceFeeCharged`.
     int64 rentFeeCharged;
 };
 


### PR DESCRIPTION
## Changes
- Add `SC_ADDRESS_TYPE_MUXED_CONTRACT` enum arm + `MuxedContract { uint64 id; ContractID contractId; }` struct + `SCAddress` union arm to `Stellar-contract.x`, all gated behind `#ifdef CAP_0084_MUXED_CONTRACT`, mirroring the existing `MuxedEd25519Account` muxed-account pattern.
- Gated, so the new types appear only in the `next` branch (built `--all-features`) and stay out of `curr` until core bumps max protocol to 28. `curr`/`next` regenerate automatically on merge — not edited here.

## Flag-token contract (downstream)
This repo is the **root of the chain** — no upstream. The ifdef token `CAP_0084_MUXED_CONTRACT` is the verbatim contract for every downstream:
- cargo feature (rs-stellar-xdr / rs-soroban-env / js-xdr-json): `cap_0084_muxed_contract`
- `XDR_FEATURES` / `xfile preprocess --features` (go-stellar-sdk / js-stellar-base): `CAP_0084_MUXED_CONTRACT`

A mismatched/truncated token silently strips the new types downstream.

## Verification
Local `stellar-xdr xfile preprocess`: arm absent with no features (curr); all three arms present and file parses with `--features CAP_0084_MUXED_CONTRACT`.

## Deferred
- Downstream PRs (rs-stellar-xdr, rs-soroban-env/-sdk, stellar-core, go-stellar-sdk, horizon, rpc, js-stellar-base/-sdk, js-stellar-xdr-json, laboratory, docker) pin this PR's head SHA — opened by their own per-repo passes.

CAP-0084: https://github.com/stellar/stellar-protocol/pull/1968