### PR TITLE
Add HAVE_TX_SET stellar-core overlay message

### DIFF
--- a/Stellar-overlay.x
+++ b/Stellar-overlay.x
@@ -124,7 +124,9 @@ enum MessageType
     TIME_SLICED_SURVEY_REQUEST = 21,
     TIME_SLICED_SURVEY_RESPONSE = 22,
     TIME_SLICED_SURVEY_START_COLLECTING = 23,
-    TIME_SLICED_SURVEY_STOP_COLLECTING = 24
+    TIME_SLICED_SURVEY_STOP_COLLECTING = 24,
+
+    HAVE_TX_SET = 25
 };
 
 struct DontHave
@@ -292,6 +294,11 @@ struct FloodDemand
     TxDemandVector txHashes;
 };
 
+struct HaveTxSet
+{
+    Hash txSetHash;
+};
+
 union StellarMessage switch (MessageType type)
 {
 case ERROR_MSG:
@@ -347,6 +354,8 @@ case FLOOD_ADVERT:
      FloodAdvert floodAdvert;
 case FLOOD_DEMAND:
      FloodDemand floodDemand;
+case HAVE_TX_SET:
+     HaveTxSet haveTxSet;
 };
 
 union AuthenticatedMessage switch (uint32 v)


### PR DESCRIPTION
Adds a new message type to allow stellar-core nodes to communicate that they possess a given transaction set. See stellar/stellar-core#5379 for the supporting stellar-core change.