### PR TITLE
Add SCSpecTypeUDTV2 with a type id

### DIFF
--- a/Stellar-contract-spec.x
+++ b/Stellar-contract-spec.x
@@ -89,7 +89,6 @@ struct SCSpecTypeUDT
 struct SCSpecTypeUDTV2
 {
     opaque id[8];
-    string name<60>;
 };
 
 union SCSpecTypeDef switch (SCSpecType type)

--- a/Stellar-contract-spec.x
+++ b/Stellar-contract-spec.x
@@ -45,7 +45,8 @@ enum SCSpecType
     SC_SPEC_TYPE_BYTES_N = 1006,
 
     // User defined types.
-    SC_SPEC_TYPE_UDT = 2000
+    SC_SPEC_TYPE_UDT = 2000,
+    SC_SPEC_TYPE_UDT_V2 = 2001
 };
 
 struct SCSpecTypeOption
@@ -85,6 +86,12 @@ struct SCSpecTypeUDT
     string name<60>;
 };
 
+struct SCSpecTypeUDTV2
+{
+    opaque id[8];
+    string name<60>;
+};
+
 union SCSpecTypeDef switch (SCSpecType type)
 {
 case SC_SPEC_TYPE_VAL:
@@ -121,6 +128,8 @@ case SC_SPEC_TYPE_BYTES_N:
     SCSpecTypeBytesN bytesN;
 case SC_SPEC_TYPE_UDT:
     SCSpecTypeUDT udt;
+case SC_SPEC_TYPE_UDT_V2:
+    SCSpecTypeUDTV2 udtV2;
 };
 
 struct SCSpecUDTStructFieldV0


### PR DESCRIPTION
> [!WARNING]
> Root of a stack of PRs that thread this field through the Rust libraries and the SDK. A valid merge order:
> 1. **this PR**
> 2. stellar/rs-stellar-xdr#560 — borrowed `Ref` variants of the generated types
> 3. stellar/rs-stellar-xdr#562 — const XDR serialization on those `Ref` types
> 4. stellar/rs-stellar-xdr#564 — regenerate with `SCSpecTypeUDTV2`
> 5. stellar/rs-soroban-env#1714 — re-pin to that regeneration
> 6. stellar/rs-soroban-sdk#1965 — encode contract spec XDR at const evaluation time
> 7. stellar/rs-soroban-sdk#1966 — reference user-defined types by id

### What

Add `SCSpecTypeUDTV2`, a second form of user-defined type reference that identifies the type it references solely by an 8-byte opaque `id`, and a `SC_SPEC_TYPE_UDT_V2` arm on `SCSpecTypeDef` holding it. The `id` is opaque here; how it is derived is left to the spec producer, and the Rust SDK derives it from the referenced type's own definition.

A reference carries no name. The name of a user-defined type lives on the definition entry the id identifies, so a consumer that wants the name resolves the id against the definitions in the same spec.

### Why

A `SCSpecTypeUDT` reference carries only a name, so a name is the only thing tying a reference to the definition it refers to. That is too weak to check anything against: names collide across libraries, and a definition whose shape changes while its name stays the same is indistinguishable from one that did not, so a consumer cannot tell whether the `UdtStruct` a function accepts is the `UdtStruct` it holds a definition for. Carrying an id that identifies the referenced type by content makes the link verifiable, and makes it well-defined for types that reference each other or themselves.

Carrying the id *instead of* the name, rather than alongside it, keeps one thing identifying the referenced type instead of two that can disagree — there is no way to express a reference whose name says one type and whose id says another. Adding a variant rather than a field on `SCSpecTypeUDT` keeps every existing spec readable unchanged.