### PR TITLE
Ungate CAP_0083 and CAP_0085_EXECUTABLE_REF ifdefs

### DIFF
--- a/Stellar-contract.x
+++ b/Stellar-contract.x
@@ -75,11 +75,9 @@ enum SCValType
     // symbolic SCVals used as the key for ledger entries for a contract's
     // instance and an address' nonce, respectively.
     SCV_LEDGER_KEY_CONTRACT_INSTANCE = 20,
-    SCV_LEDGER_KEY_NONCE = 21
+    SCV_LEDGER_KEY_NONCE = 21,
 
-#ifdef CAP_0085_EXECUTABLE_REF
-    ,SCV_EXECUTABLE_TAG = 22
-#endif
+    SCV_EXECUTABLE_TAG = 22
 };
 
 enum SCErrorType
@@ -174,10 +172,8 @@ struct Int256Parts {
 enum ContractExecutableType
 {
     CONTRACT_EXECUTABLE_WASM = 0,
-    CONTRACT_EXECUTABLE_STELLAR_ASSET = 1
-#ifdef CAP_0085_EXECUTABLE_REF
-    ,CONTRACT_EXECUTABLE_EXTERNAL_REF = 2
-#endif
+    CONTRACT_EXECUTABLE_STELLAR_ASSET = 1,
+    CONTRACT_EXECUTABLE_EXTERNAL_REF = 2
 };
 
 enum SCAddressType
@@ -225,12 +221,10 @@ case SC_ADDRESS_TYPE_MUXED_CONTRACT:
 #endif
 };
 
-#ifdef CAP_0085_EXECUTABLE_REF
 struct ContractExecutableExternalRef {
     SCAddress executable_owner;
     SCString tag;
 };
-#endif
 
 union ContractExecutable switch (ContractExecutableType type)
 {
@@ -238,10 +232,8 @@ case CONTRACT_EXECUTABLE_WASM:
     Hash wasm_hash;
 case CONTRACT_EXECUTABLE_STELLAR_ASSET:
     void;
-#ifdef CAP_0085_EXECUTABLE_REF
 case CONTRACT_EXECUTABLE_EXTERNAL_REF:
     ContractExecutableExternalRef external_ref;
-#endif
 };
 
 %struct SCVal;
@@ -319,10 +311,8 @@ case SCV_LEDGER_KEY_CONTRACT_INSTANCE:
 case SCV_LEDGER_KEY_NONCE:
     SCNonceKey nonce_key;
 
-#ifdef CAP_0085_EXECUTABLE_REF
 case SCV_EXECUTABLE_TAG:
     SCString executable_tag;
-#endif    
 };
 
 struct SCMapEntry

--- a/Stellar-ledger.x
+++ b/Stellar-ledger.x
@@ -13,11 +13,8 @@ typedef opaque UpgradeType<128>;
 enum StellarValueType
 {
     STELLAR_VALUE_BASIC = 0,
-    STELLAR_VALUE_SIGNED = 1
-#ifdef CAP_0083
-    ,
+    STELLAR_VALUE_SIGNED = 1,
     STELLAR_VALUE_EMPTY_TX_SET = 2
-#endif
 };
 
 struct LedgerCloseValueSignature
@@ -47,7 +44,6 @@ struct StellarValue
         void;
     case STELLAR_VALUE_SIGNED:
         LedgerCloseValueSignature lcValueSignature;
-#ifdef CAP_0083
     case STELLAR_VALUE_EMPTY_TX_SET:
         struct
         {
@@ -56,7 +52,6 @@ struct StellarValue
             uint32 previousLedgerVersion;
             LedgerCloseValueSignature lcValueSignature;
         } proposedValue;
-#endif
     }
     ext;
 };


### PR DESCRIPTION
Removes the `#ifdef CAP_0083` and `#ifdef CAP_0085_EXECUTABLE_REF` gating so both CAPs' definitions are unconditional and land in `curr` as well as `next`. Same shape as #303.

`CAP_0084_MUXED_CONTRACT` stays gated. CAP-0086 has no XDR changes.

First of the P28 ungating stack: rs-stellar-xdr → rs-soroban-env → stellar-core follow.