### PR TITLE
Add ids to contract spec entries

### DIFF
--- a/Stellar-contract-spec.x
+++ b/Stellar-contract-spec.x
@@ -12,12 +12,12 @@ namespace stellar
 
 const SC_SPEC_DOC_LIMIT = 1024;
 
-// The number of bytes in a user-defined type id. A type id is the SHA-256
-// hash of the fully qualified name of the type a reference refers to,
-// truncated to this length. Ids are unique within the build that produced
-// the contract, across the crates that make it up, even when types share a
-// name.
-const SC_SPEC_TYPE_ID_LEN = 8;
+// The number of bytes in a spec id. An id is the SHA-256 hash of the fully
+// qualified name of the item a spec entry describes, or a reference refers
+// to, truncated to this length. Ids are unique within the build that
+// produced the contract, across the crates that make it up, even when items
+// share a name.
+const SC_SPEC_ID_LEN = 8;
 
 enum SCSpecType
 {
@@ -99,7 +99,7 @@ struct SCSpecTypeUDT
 struct SCSpecTypeUDTV2
 {
     string name<60>;
-    opaque id[SC_SPEC_TYPE_ID_LEN];
+    opaque id[SC_SPEC_ID_LEN];
 };
 
 union SCSpecTypeDef switch (SCSpecType type)
@@ -275,7 +275,32 @@ enum SCSpecEntryKind
     SC_SPEC_ENTRY_UDT_UNION_V0 = 2,
     SC_SPEC_ENTRY_UDT_ENUM_V0 = 3,
     SC_SPEC_ENTRY_UDT_ERROR_ENUM_V0 = 4,
-    SC_SPEC_ENTRY_EVENT_V0 = 5
+    SC_SPEC_ENTRY_EVENT_V0 = 5,
+    SC_SPEC_ENTRY_V2 = 6
+};
+
+// An entry paired with the id that uniquely identifies it. The id is the
+// SHA-256 hash of the fully qualified name of the item the entry describes,
+// truncated to SC_SPEC_ID_LEN. A reference carrying an id, such as
+// SCSpecTypeUDTV2, refers to the entry whose id matches.
+struct SCSpecEntryV2
+{
+    opaque id[SC_SPEC_ID_LEN];
+    union switch (SCSpecEntryKind kind)
+    {
+    case SC_SPEC_ENTRY_FUNCTION_V0:
+        SCSpecFunctionV0 functionV0;
+    case SC_SPEC_ENTRY_UDT_STRUCT_V0:
+        SCSpecUDTStructV0 udtStructV0;
+    case SC_SPEC_ENTRY_UDT_UNION_V0:
+        SCSpecUDTUnionV0 udtUnionV0;
+    case SC_SPEC_ENTRY_UDT_ENUM_V0:
+        SCSpecUDTEnumV0 udtEnumV0;
+    case SC_SPEC_ENTRY_UDT_ERROR_ENUM_V0:
+        SCSpecUDTErrorEnumV0 udtErrorEnumV0;
+    case SC_SPEC_ENTRY_EVENT_V0:
+        SCSpecEventV0 eventV0;
+    } body;
 };
 
 union SCSpecEntry switch (SCSpecEntryKind kind)
@@ -292,6 +317,8 @@ case SC_SPEC_ENTRY_UDT_ERROR_ENUM_V0:
     SCSpecUDTErrorEnumV0 udtErrorEnumV0;
 case SC_SPEC_ENTRY_EVENT_V0:
     SCSpecEventV0 eventV0;
+case SC_SPEC_ENTRY_V2:
+    SCSpecEntryV2 v2;
 };
 
 }

--- a/Stellar-contract-spec.x
+++ b/Stellar-contract-spec.x
@@ -13,9 +13,10 @@ namespace stellar
 const SC_SPEC_DOC_LIMIT = 1024;
 
 // The number of bytes in a user-defined type id. A type id is the SHA-256
-// hash of the type's fully qualified name, truncated to this length. Ids are
-// unique within the build that produced the contract, across the crates that
-// make it up, even when types share a name.
+// hash of the fully qualified name of the type a reference refers to,
+// truncated to this length. Ids are unique within the build that produced
+// the contract, across the crates that make it up, even when types share a
+// name.
 const SC_SPEC_TYPE_ID_LEN = 8;
 
 enum SCSpecType
@@ -92,9 +93,9 @@ struct SCSpecTypeUDT
     string name<60>;
 };
 
-// A reference to a user-defined type by name and id. The id matches the id
-// of the type's definition entry exactly, so the reference is unambiguous
-// even when types share a name.
+// A reference to a user-defined type by name and id. The id identifies the
+// referenced type exactly, so two references are known to refer to the same
+// type, or to different types, even when the types share a name.
 struct SCSpecTypeUDTV2
 {
     string name<60>;
@@ -153,7 +154,6 @@ struct SCSpecUDTStructV0
     string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
     string name<60>;
-    opaque id[SC_SPEC_TYPE_ID_LEN];
     SCSpecUDTStructFieldV0 fields<>;
 };
 
@@ -189,7 +189,6 @@ struct SCSpecUDTUnionV0
     string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
     string name<60>;
-    opaque id[SC_SPEC_TYPE_ID_LEN];
     SCSpecUDTUnionCaseV0 cases<>;
 };
 
@@ -205,7 +204,6 @@ struct SCSpecUDTEnumV0
     string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
     string name<60>;
-    opaque id[SC_SPEC_TYPE_ID_LEN];
     SCSpecUDTEnumCaseV0 cases<>;
 };
 
@@ -221,7 +219,6 @@ struct SCSpecUDTErrorEnumV0
     string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
     string name<60>;
-    opaque id[SC_SPEC_TYPE_ID_LEN];
     SCSpecUDTErrorEnumCaseV0 cases<>;
 };
 

--- a/Stellar-contract-spec.x
+++ b/Stellar-contract-spec.x
@@ -12,6 +12,12 @@ namespace stellar
 
 const SC_SPEC_DOC_LIMIT = 1024;
 
+// The number of bytes in a user-defined type id. A type id is the SHA-256
+// hash of the type's fully qualified name, truncated to this length. Ids are
+// unique within the build that produced the contract, across the crates that
+// make it up, even when types share a name.
+const SC_SPEC_TYPE_ID_LEN = 8;
+
 enum SCSpecType
 {
     SC_SPEC_TYPE_VAL = 0,
@@ -45,7 +51,8 @@ enum SCSpecType
     SC_SPEC_TYPE_BYTES_N = 1006,
 
     // User defined types.
-    SC_SPEC_TYPE_UDT = 2000
+    SC_SPEC_TYPE_UDT = 2000,
+    SC_SPEC_TYPE_UDT_V2 = 2001
 };
 
 struct SCSpecTypeOption
@@ -85,6 +92,15 @@ struct SCSpecTypeUDT
     string name<60>;
 };
 
+// A reference to a user-defined type by name and id. The id matches the id
+// of the type's definition entry exactly, so the reference is unambiguous
+// even when types share a name.
+struct SCSpecTypeUDTV2
+{
+    string name<60>;
+    opaque id[SC_SPEC_TYPE_ID_LEN];
+};
+
 union SCSpecTypeDef switch (SCSpecType type)
 {
 case SC_SPEC_TYPE_VAL:
@@ -121,6 +137,8 @@ case SC_SPEC_TYPE_BYTES_N:
     SCSpecTypeBytesN bytesN;
 case SC_SPEC_TYPE_UDT:
     SCSpecTypeUDT udt;
+case SC_SPEC_TYPE_UDT_V2:
+    SCSpecTypeUDTV2 udtV2;
 };
 
 struct SCSpecUDTStructFieldV0
@@ -135,6 +153,7 @@ struct SCSpecUDTStructV0
     string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
     string name<60>;
+    opaque id[SC_SPEC_TYPE_ID_LEN];
     SCSpecUDTStructFieldV0 fields<>;
 };
 
@@ -170,6 +189,7 @@ struct SCSpecUDTUnionV0
     string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
     string name<60>;
+    opaque id[SC_SPEC_TYPE_ID_LEN];
     SCSpecUDTUnionCaseV0 cases<>;
 };
 
@@ -185,6 +205,7 @@ struct SCSpecUDTEnumV0
     string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
     string name<60>;
+    opaque id[SC_SPEC_TYPE_ID_LEN];
     SCSpecUDTEnumCaseV0 cases<>;
 };
 
@@ -200,6 +221,7 @@ struct SCSpecUDTErrorEnumV0
     string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
     string name<60>;
+    opaque id[SC_SPEC_TYPE_ID_LEN];
     SCSpecUDTErrorEnumCaseV0 cases<>;
 };
 


### PR DESCRIPTION
> [!NOTE]
> Part of a stack of PRs that must merge in this order.
>
> A first group of PRs deliver const-encoded contract specs, so that contract specs are produced at compile time instead of at proc-macro execution time. This provides the foundation for the capability to construct the specs from information that is not known at proc-macro execution and only known at compile time, like the fully qualified name of a type:
> 1. stellar/rs-stellar-xdr#560
> 1. stellar/rs-stellar-xdr#562
> 1. stellar/rs-soroban-sdk#1965
>
> A second group of PRs deliver ids on contract spec entries and in spec references. Every entry carries an 8-byte id hashed from the fully qualified name of the item it describes, and a reference to a user-defined type carries the id of the entry it refers to, so references stay unambiguous even when items share a name. This resolves the type identity problem (https://github.com/stellar/rs-soroban-sdk/issues/1570) and type alias limitations (https://github.com/stellar/rs-soroban-sdk/issues/1857):
> 1. stellar/stellar-xdr#313 ← this PR
> 1. stellar/rs-stellar-xdr#568
> 1. stellar/rs-soroban-sdk#1998
> 1. stellar/stellar-cli#2677

### What

Add a new `SCSpecEntryV2` entry that pairs an 8-byte `id` with a body union reusing the existing V0 entry bodies (function, UDT struct/union/enum/error enum, event), exposed as a new `SC_SPEC_ENTRY_V2` arm of `SCSpecEntry`. Add a `SCSpecTypeUDTV2` reference type carrying the referenced type's name and the id of the entry it refers to. A `SC_SPEC_ID_LEN` const defines the id length. The id is the truncated SHA-256 of the fully qualified name of the item the entry describes.

The change is purely additive: the existing V0 entry arms, the V0 body structs, and the existing `SCSpecTypeUDT` reference are unchanged, so existing specs continue to decode.

### Why

A bare name cannot tell two items apart: two crates, or two modules of one crate, can each define a `Flag`, and a spec that names both simply `Flag` cannot say which is which. An id derived from the item's fully qualified name identifies it exactly, so every entry has a unique identifier and a reference is known to refer to one entry precisely, even when entries share a name.

The id lives at the top level of the entry — beside the body, not inside it — so every entry kind gets an id the same way, functions and events included, and the body structs stay unchanged.