### PR TITLE
Check SCSpecType is a superset of SCValType

### DIFF
--- a/.github/workflows/scspectype-superset.yml
+++ b/.github/workflows/scspectype-superset.yml
@@ -1,0 +1,21 @@
+name: SCSpecType Superset
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: lts/*
+
+      - run: node .scripts/check-scspectype-superset.ts

--- a/.github/workflows/scspectype-superset.yml
+++ b/.github/workflows/scspectype-superset.yml
@@ -2,6 +2,7 @@ name: SCSpecType Superset
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.scripts/check-scspectype-superset.ts
+++ b/.scripts/check-scspectype-superset.ts
@@ -1,0 +1,33 @@
+// Every SCValType that can appear at a contract function boundary must be
+// expressible in a contract spec, so SCSpecType needs a counterpart for it.
+// The names line up by prefix: SCV_U32 -> SC_SPEC_TYPE_U32.
+
+import { readFileSync } from "node:fs";
+
+// SCValType variants that cannot cross a contract function boundary, and so
+// intentionally have no SCSpecType counterpart.
+const EXCLUDED = [
+  "CONTRACT_INSTANCE",
+  "LEDGER_KEY_CONTRACT_INSTANCE",
+  "LEDGER_KEY_NONCE",
+];
+
+const spec = readFileSync("Stellar-contract-spec.x", "utf8");
+const val = readFileSync("Stellar-contract.x", "utf8").match(/\bSCV_\w+/g) ?? [];
+
+const missing = [...new Set(val.map((name) => name.slice("SCV_".length)))]
+  .filter((name) => !EXCLUDED.includes(name))
+  .filter((name) => !new RegExp(`\\bSC_SPEC_TYPE_${name}\\b`).test(spec));
+
+if (missing.length > 0) {
+  console.log(`
+SCValType variants with no SCSpecType counterpart: ${missing.map((n) => "SCV_" + n).join(", ")}
+
+SCSpecType must be a superset of SCValType so that every value type usable at a
+contract function boundary can be captured in a contract spec. Either add the
+missing SCSpecType variant, or, if the value cannot cross a contract boundary,
+add it to EXCLUDED in this script.`);
+  process.exit(1);
+}
+
+console.log("SCSpecType covers every SCValType variant.");


### PR DESCRIPTION
### What

Add a CI check that every `SCValType` variant has a matching `SC_SPEC_TYPE_` counterpart, excluding the three internal values that cannot cross a contract function boundary.

### Why

Nothing catches a new `SCValType` landing without a corresponding `SCSpecType`, which leaves a value type that contracts can pass but cannot declare in their spec — the check fails today on `SCV_EXECUTABLE_TAG`.
